### PR TITLE
VD-1070: Add pppoe-Added-option-enable-pass-nd-and-dhcpv6 patch

### DIFF
--- a/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
+++ b/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
@@ -1,7 +1,7 @@
 From a3ebed1641deca92e4eae2b32d34dbe5fc5e9f57 Mon Sep 17 00:00:00 2001
 From: Aakash <saakashkumar@marvell.com>
 Date: Mon, 1 Aug 2022 04:59:02 -0400
-Subject: [PATCH 01/19] linux-cp: add support for xfrm netlink notifcation
+Subject: [PATCH 01/20] linux-cp: add support for xfrm netlink notifcation
 
 This patch contains changes to add support for handlng xfrm
 notifications in linux-cp plugin.
@@ -2473,5 +2473,5 @@ index 000000000..21497cde9
 + * End:
 + */
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
+++ b/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
@@ -1,7 +1,7 @@
 From b2bce6dc411175928d52e207d8890403af1f4792 Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Tue, 6 Feb 2024 23:23:14 +0530
-Subject: [PATCH 02/19] linux-cp: update code to support api proto changes
+Subject: [PATCH 02/20] linux-cp: update code to support api proto changes
 
 Type: fix
 
@@ -28,5 +28,5 @@ index 5b3a46058..3e5904454 100644
      {
        NL_XFRM_ERR ("ipsec sa add %x failure(err: %d) %U -> %U", id, rv,
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
+++ b/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
@@ -1,7 +1,7 @@
 From 2a1f214e452225b78150a0fa8fa0938a9d55e118 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 5 Dec 2023 18:25:33 +0000
-Subject: [PATCH 03/19] linux-cp: add ipsec interface support for xfrm
+Subject: [PATCH 03/20] linux-cp: add ipsec interface support for xfrm
 
 This patch adds ipsec interface support for strongswan
 based SA configuration.
@@ -306,5 +306,5 @@ index 21497cde9..4eabf40e6 100644
  }
  
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
+++ b/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
@@ -1,7 +1,7 @@
 From 8ffe977acdba505759bd6645871ab976c7fbce87 Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Wed, 7 Feb 2024 11:58:17 +0530
-Subject: [PATCH 04/19] linux-cp: initialize sw_if_index variable
+Subject: [PATCH 04/20] linux-cp: initialize sw_if_index variable
 
 Type: fix
 
@@ -28,5 +28,5 @@ index 79194c226..fe83a948a 100644
    u8 *s = NULL;
    u8 instance = xfrmnl_sa_get_reqid (sa);
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
+++ b/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
@@ -1,7 +1,7 @@
 From 57f0bafafe203da5f7fa04efbc2e850e391f3589 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Sun, 24 Mar 2024 08:36:48 +0000
-Subject: [PATCH 05/19] linux-cp: add readme for xfrm implementation
+Subject: [PATCH 05/20] linux-cp: add readme for xfrm implementation
 
 This patch adds REAMDE for XFRM changes design and startup.conf
 configuration details.
@@ -199,5 +199,5 @@ index 000000000..9e63646dd
 + nl-batch-delay-ms <>
 +}
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
+++ b/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
@@ -1,7 +1,7 @@
 From 3aee268143607b829b9e006ff3d72dfb67bd919b Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 27 Aug 2024 17:29:30 +0000
-Subject: [PATCH 06/19] linux-cp: fix esn and anti-replay issue
+Subject: [PATCH 06/20] linux-cp: fix esn and anti-replay issue
 
 This patch enables anti-replay when ESN is enabled on a Security
 Association (SA) configured via strongSwan.
@@ -36,5 +36,5 @@ index fe83a948a..c847e699f 100644
    /*
     * Kernel SA XFRM doesnt have a flag for AR config. So a non-zero
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
+++ b/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
@@ -1,7 +1,7 @@
 From 48d57e9543244fb29b8e9bdce4d5775950332e9d Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 1 Oct 2024 15:06:41 +0000
-Subject: [PATCH 07/19] linux-cp: fix ipsec policy incorrect protocol type
+Subject: [PATCH 07/20] linux-cp: fix ipsec policy incorrect protocol type
 
 This patch changes protocol type 0 to IPSEC_POLICY_PROTOCOL_ANY to
 allow any transport protocol for protect/bypass.
@@ -51,5 +51,5 @@ index c847e699f..ff6e79649 100644
  
    lcp_xfrm_mk_ipaddr (sel_dst, &sel_daddr);
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
+++ b/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 28a3d6f27e0237f07d71a305191a814e07550128 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Wed, 12 Feb 2025 12:29:57 +0200
-Subject: [PATCH 08/19] linux-cp: Added build dependency for XFRM
+Subject: [PATCH 08/20] linux-cp: Added build dependency for XFRM
 
 Added `libnl-xfrm-3-200` to build dependencies to make build
 `linux-cp` with XFRM possible.
@@ -24,5 +24,5 @@ index 98866e9be..aa0e99e65 100644
  LIBFFI=libffi6 # works on all but 20.04 and debian-testing
  ifeq ($(OS_VERSION_ID),24.04)
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From c784244ca4092210ea74fcff1ec7c1a7d633e2ff Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 09/19] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 09/20] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:
@@ -182,5 +182,5 @@ index 0efd53e64..0879d00bc 100644
         (ip6_address_is_multicast (&pfx.fp_addr.ip6) ||
  	ip6_address_is_link_local_unicast (&pfx.fp_addr.ip6))))
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
+++ b/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
@@ -1,7 +1,7 @@
 From d66645af550b6916e11f3923c1fbaf511094e1b8 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 24 Jul 2024 08:35:25 +0000
-Subject: [PATCH 10/19] Resync ip fib with Linux state.
+Subject: [PATCH 10/20] Resync ip fib with Linux state.
 
 A new CLI and API file option is available:
 
@@ -197,5 +197,5 @@ index 85b644700..0b2536ccc 100644
  	   * reduce the number of failed attempts that stall the main thread by
  	   * waiting out the notification storm
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
+++ b/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
@@ -1,7 +1,7 @@
 From 9653065d5de59ab76e10f67117896f7ed6478585 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 29 Jan 2025 11:57:01 +0200
-Subject: [PATCH 11/19] LCP: Improved lcp resync CLI and API to wait until
+Subject: [PATCH 11/20] LCP: Improved lcp resync CLI and API to wait until
  Netlink sync is finished.
 
 (cherry picked from commit b19375e7e42023a5cdca84f259036574ccd9da77)
@@ -341,5 +341,5 @@ index 000000000..f9005b6fc
 + * End:
 + */
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
+++ b/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
@@ -1,7 +1,7 @@
 From e34ad0e3b7ae9f4e630687e39278e5dd43a43c31 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Tue, 11 Feb 2025 20:33:46 +0200
-Subject: [PATCH 12/19] build: Fixed compatibility with build on Debian 12
+Subject: [PATCH 12/20] build: Fixed compatibility with build on Debian 12
 
 (cherry picked from commit ca7d5bcd381edb68e9d4ae6ffa915bda4d2c1adf)
 ---
@@ -21,5 +21,5 @@ index aa0e99e65..d3d433ddb 100644
  	# TODO: remove once ubuntu 20.04 is deprecated and extras/scripts/checkstyle.sh is upgraded to -15
  	export CLANG_FORMAT_VER=15
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
+++ b/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 44830bdae2c4cefe94dd3c8ceee471b7dadeef8b Mon Sep 17 00:00:00 2001
 From: Viacheslav Hletenko <v.gletenko@vyos.io>
 Date: Thu, 13 Feb 2025 11:37:36 +0000
-Subject: [PATCH 13/19] linux-cp: Added build dependency libunwind8 for XFRM
+Subject: [PATCH 13/20] linux-cp: Added build dependency libunwind8 for XFRM
 
 Added `libunwind8` to build dependencies required by
 `linux-cp` for XFRM
@@ -22,5 +22,5 @@ index d3d433ddb..82b42bfef 100644
  LIBFFI=libffi6 # works on all but 20.04 and debian-testing
  ifeq ($(OS_VERSION_ID),24.04)
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From 0696c16075caa700a0c9313400c67582da42de99 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Thu, 6 Mar 2025 16:27:51 +0200
-Subject: [PATCH 14/19] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 14/20] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit c784244ca4092210ea74fcff1ec7c1a7d633e2ff.
@@ -166,5 +166,5 @@ index 0879d00bc..0efd53e64 100644
         (ip6_address_is_multicast (&pfx.fp_addr.ip6) ||
  	ip6_address_is_link_local_unicast (&pfx.fp_addr.ip6))))
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From 5583626fe1a9d11cffb8f759c996e341b7e54a7b Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 15/19] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 15/20] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:
@@ -280,5 +280,5 @@ index 0efd53e64..6848f3d1c 100644
    if (0 != vec_len (np.paths))
      {
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From 350e148db0fb9708fb234e68e2eaa8500a0248d1 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 18 Mar 2025 21:32:51 +0200
-Subject: [PATCH 16/19] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 16/20] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit 5583626fe1a9d11cffb8f759c996e341b7e54a7b.
@@ -244,5 +244,5 @@ index 6848f3d1c..0efd53e64 100644
    if (0 != vec_len (np.paths))
      {
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From 322efbd2c42c6c5007e601de6c752a6197385370 Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 17/19] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 17/20] linux-cp: Added routing for prefixes with no paths
  available
 
 Fixed GRE crashes in IPv4 and IPv6 FIB.
@@ -360,5 +360,5 @@ index ff74b52eb..80688a097 100644
    if (is_receive_dpo)
      {
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
+++ b/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
@@ -1,7 +1,7 @@
 From 49b7e3f139ea56cda05a9a687b933a350b2e7d71 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 15 May 2025 17:18:48 +0300
-Subject: [PATCH 18/19] pppoe. Automated session management. (#12)
+Subject: [PATCH 18/20] pppoe. Automated session management. (#12)
 
 Purpose of Changes:
 Automate PPPoE session management by sniffing LCP, IPCP and PADT control frames.
@@ -1384,5 +1384,5 @@ index b2daadba8..ecb8d7f4c 100644
    S (mp);
    W (ret);
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0019-vapi-fix-vapi_ctx_alloc.patch
+++ b/patches/vpp/0019-vapi-fix-vapi_ctx_alloc.patch
@@ -1,7 +1,7 @@
 From 61646528090c8bfa130d24a1e287fd4e37742adb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Beno=C3=AEt=20Ganne?= <bganne@cisco.com>
 Date: Fri, 29 Nov 2024 14:14:16 +0100
-Subject: [PATCH 19/19] vapi: fix vapi_ctx_alloc
+Subject: [PATCH 19/20] vapi: fix vapi_ctx_alloc
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -45,5 +45,5 @@ index 26c570834..e2e4bb02d 100644
    const size_t size = ctx->requests_size * sizeof (*ctx->requests);
    void *tmp = realloc (ctx->requests, size);
 -- 
-2.39.5
+2.43.0
 

--- a/patches/vpp/0020-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
+++ b/patches/vpp/0020-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
@@ -1,0 +1,99 @@
+From db653f726ee47e87554cf98d18dfc921fe5b4e08 Mon Sep 17 00:00:00 2001
+From: Andrii Melnychenko <a.melnychenko@vyos.io>
+Date: Thu, 10 Jul 2025 17:42:44 +0200
+Subject: [PATCH 20/20] pppoe: Added option "enable-pass-nd-and-dhcpv6"
+
+This option would allow to pass ICMPv6 sl & ra and
+UDP-DHCPv6 packets to the PPPoE control plane.
+
+Signed-off-by: Andrii Melnychenko <a.melnychenko@vyos.io>
+---
+ src/plugins/pppoe/pppoe.c       |  2 ++
+ src/plugins/pppoe/pppoe.h       |  1 +
+ src/plugins/pppoe/pppoe_decap.c | 13 +++++++------
+ 3 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/src/plugins/pppoe/pppoe.c b/src/plugins/pppoe/pppoe.c
+index c6b6cf0ba..734137f63 100644
+--- a/src/plugins/pppoe/pppoe.c
++++ b/src/plugins/pppoe/pppoe.c
+@@ -1024,6 +1024,8 @@ pppoe_config (vlib_main_t *vm, unformat_input_t *input)
+     {
+       if (unformat (input, "enable-auto-discovery"))
+ 	pem->is_auto_discovery = 1;
++      else if (unformat (input, "enable-pass-nd-and-dhcpv6"))
++	pem->is_pass_nd_and_dhcpv6 = 1;
+       else
+ 	return clib_error_return (0, "invalid pppoe option: %U",
+ 				  format_unformat_error, input);
+diff --git a/src/plugins/pppoe/pppoe.h b/src/plugins/pppoe/pppoe.h
+index a23fe865c..231daae67 100644
+--- a/src/plugins/pppoe/pppoe.h
++++ b/src/plugins/pppoe/pppoe.h
+@@ -196,6 +196,7 @@ typedef struct
+   vnet_main_t *vnet_main;
+ 
+   u8 is_auto_discovery;
++  u8 is_pass_nd_and_dhcpv6;
+ 
+ } pppoe_main_t;
+ 
+diff --git a/src/plugins/pppoe/pppoe_decap.c b/src/plugins/pppoe/pppoe_decap.c
+index 7263a58a1..7f47923ef 100644
+--- a/src/plugins/pppoe/pppoe_decap.c
++++ b/src/plugins/pppoe/pppoe_decap.c
+@@ -47,7 +47,7 @@ static u8 * format_pppoe_rx_trace (u8 * s, va_list * args)
+ }
+ 
+ static inline int
+-is_control_plane_packet (pppoe_header_t *pppoe0, bool is_auto_discovery)
++is_control_plane_packet (pppoe_header_t *pppoe0, bool is_pass_nd_and_dhcpv6)
+ {
+   u16 ppp_proto = clib_net_to_host_u16 (pppoe0->ppp_proto);
+ 
+@@ -56,12 +56,13 @@ is_control_plane_packet (pppoe_header_t *pppoe0, bool is_auto_discovery)
+ 
+   if (ppp_proto == PPP_PROTOCOL_ip6)
+     {
+-      if (!is_auto_discovery)
++      if (!is_pass_nd_and_dhcpv6)
+ 	return 0;
+ 
+       ip6_header_t *ip6 =
+ 	(ip6_header_t *) ((u8 *) pppoe0 + sizeof (pppoe_header_t));
+-      if (ip6->protocol == IP_PROTOCOL_ICMP6)
++      icmp46_header_t *icmp = (icmp46_header_t *)(ip6 + 1);
++      if (ip6->protocol == IP_PROTOCOL_ICMP6 && (icmp->type == ICMP6_router_solicitation || icmp->type == ICMP6_router_advertisement))
+ 	{
+ 	  return 1;
+ 	}
+@@ -186,7 +187,7 @@ VLIB_NODE_FN (pppoe_input_node) (vlib_main_t * vm,
+           ppp_proto0 = clib_net_to_host_u16(pppoe0->ppp_proto);          
+ 
+           /* Manipulate packet 0 */
+-		  if (is_control_plane_packet(pppoe0, pem->is_auto_discovery))
++		  if (is_control_plane_packet(pppoe0, pem->is_pass_nd_and_dhcpv6))
+             {
+ 		  vlan0 == 0 ?
+ 	  	    vlib_buffer_advance(b0, sizeof(*h0))
+@@ -283,7 +284,7 @@ VLIB_NODE_FN (pppoe_input_node) (vlib_main_t * vm,
+ 		  ppp_proto1 = clib_net_to_host_u16(pppoe1->ppp_proto);
+ 
+           /* Manipulate packet 1 */
+-          if (is_control_plane_packet(pppoe1, pem->is_auto_discovery))
++          if (is_control_plane_packet(pppoe1, pem->is_pass_nd_and_dhcpv6))
+             {
+ 		  vlan1 == 0 ?
+ 	  	    vlib_buffer_advance(b1, sizeof(*h1))
+@@ -410,7 +411,7 @@ VLIB_NODE_FN (pppoe_input_node) (vlib_main_t * vm,
+ 
+           ppp_proto0 = clib_net_to_host_u16(pppoe0->ppp_proto);   
+ 
+-          if (is_control_plane_packet(pppoe0, pem->is_auto_discovery))
++          if (is_control_plane_packet(pppoe0, pem->is_pass_nd_and_dhcpv6))
+             {
+ 		  vlan0 == 0 ?
+ 	  	    vlib_buffer_advance(b0, sizeof(*h0))
+-- 
+2.43.0
+


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
