### PR TITLE
T7770: T7775: Add XFRM AEAD-AES-GCM support patches

### DIFF
--- a/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
+++ b/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
@@ -1,7 +1,7 @@
 From a3240c47714ae9ed447581c3557983630bb5f825 Mon Sep 17 00:00:00 2001
 From: Aakash <saakashkumar@marvell.com>
 Date: Mon, 1 Aug 2022 04:59:02 -0400
-Subject: [PATCH 01/22] linux-cp: add support for xfrm netlink notifcation
+Subject: [PATCH 01/24] linux-cp: add support for xfrm netlink notifcation
 
 This patch contains changes to add support for handlng xfrm
 notifications in linux-cp plugin.

--- a/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
+++ b/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
@@ -1,7 +1,7 @@
 From e238d4e62e66ed9a9e01425a844d57cc33ec316e Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Tue, 6 Feb 2024 23:23:14 +0530
-Subject: [PATCH 02/22] linux-cp: update code to support api proto changes
+Subject: [PATCH 02/24] linux-cp: update code to support api proto changes
 
 Type: fix
 

--- a/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
+++ b/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
@@ -1,7 +1,7 @@
 From 70286cf59119cc1c122d449ee3fd678646ae1b40 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 5 Dec 2023 18:25:33 +0000
-Subject: [PATCH 03/22] linux-cp: add ipsec interface support for xfrm
+Subject: [PATCH 03/24] linux-cp: add ipsec interface support for xfrm
 
 This patch adds ipsec interface support for strongswan
 based SA configuration.

--- a/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
+++ b/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
@@ -1,7 +1,7 @@
 From 0a6768dea23e4bf4621dac89b166b869f54cc53f Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Wed, 7 Feb 2024 11:58:17 +0530
-Subject: [PATCH 04/22] linux-cp: initialize sw_if_index variable
+Subject: [PATCH 04/24] linux-cp: initialize sw_if_index variable
 
 Type: fix
 

--- a/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
+++ b/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
@@ -1,7 +1,7 @@
 From 33348f8e70e26c3fa93ca921cafef5e9af85337c Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Sun, 24 Mar 2024 08:36:48 +0000
-Subject: [PATCH 05/22] linux-cp: add readme for xfrm implementation
+Subject: [PATCH 05/24] linux-cp: add readme for xfrm implementation
 
 This patch adds REAMDE for XFRM changes design and startup.conf
 configuration details.

--- a/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
+++ b/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
@@ -1,7 +1,7 @@
 From adff1ecb857315e7d3e735efe31dc9b322183732 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 27 Aug 2024 17:29:30 +0000
-Subject: [PATCH 06/22] linux-cp: fix esn and anti-replay issue
+Subject: [PATCH 06/24] linux-cp: fix esn and anti-replay issue
 
 This patch enables anti-replay when ESN is enabled on a Security
 Association (SA) configured via strongSwan.

--- a/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
+++ b/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
@@ -1,7 +1,7 @@
 From e5d9989fe860fd394d131c791c3e74bd8952c230 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 1 Oct 2024 15:06:41 +0000
-Subject: [PATCH 07/22] linux-cp: fix ipsec policy incorrect protocol type
+Subject: [PATCH 07/24] linux-cp: fix ipsec policy incorrect protocol type
 
 This patch changes protocol type 0 to IPSEC_POLICY_PROTOCOL_ANY to
 allow any transport protocol for protect/bypass.

--- a/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
+++ b/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 56275b6a0dbe20b8eb77a16b6525a34ab71b33ca Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Wed, 12 Feb 2025 12:29:57 +0200
-Subject: [PATCH 08/22] linux-cp: Added build dependency for XFRM
+Subject: [PATCH 08/24] linux-cp: Added build dependency for XFRM
 
 Added `libnl-xfrm-3-200` to build dependencies to make build
 `linux-cp` with XFRM possible.

--- a/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From a5f3779078cd93cfc821a23c681af68d1a3a39cf Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 09/22] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 09/24] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:

--- a/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
+++ b/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
@@ -1,7 +1,7 @@
 From d87a33a4dd33f04dce319a1e410bc811808fb7b1 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 24 Jul 2024 08:35:25 +0000
-Subject: [PATCH 10/22] Resync ip fib with Linux state.
+Subject: [PATCH 10/24] Resync ip fib with Linux state.
 
 A new CLI and API file option is available:
 

--- a/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
+++ b/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
@@ -1,7 +1,7 @@
 From 759521ff07dcfb69a09d432e943319a8422ee47c Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 29 Jan 2025 11:57:01 +0200
-Subject: [PATCH 11/22] LCP: Improved lcp resync CLI and API to wait until
+Subject: [PATCH 11/24] LCP: Improved lcp resync CLI and API to wait until
  Netlink sync is finished.
 
 (cherry picked from commit b19375e7e42023a5cdca84f259036574ccd9da77)

--- a/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
+++ b/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
@@ -1,7 +1,7 @@
 From 99f5622c6945c0055e1a3dea4cd925bee1fecf31 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Tue, 11 Feb 2025 20:33:46 +0200
-Subject: [PATCH 12/22] build: Fixed compatibility with build on Debian 12
+Subject: [PATCH 12/24] build: Fixed compatibility with build on Debian 12
 
 (cherry picked from commit ca7d5bcd381edb68e9d4ae6ffa915bda4d2c1adf)
 ---

--- a/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
+++ b/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 4958c7a4553d03532032c20932f5ab5905bff904 Mon Sep 17 00:00:00 2001
 From: Viacheslav Hletenko <v.gletenko@vyos.io>
 Date: Thu, 13 Feb 2025 11:37:36 +0000
-Subject: [PATCH 13/22] linux-cp: Added build dependency libunwind8 for XFRM
+Subject: [PATCH 13/24] linux-cp: Added build dependency libunwind8 for XFRM
 
 Added `libunwind8` to build dependencies required by
 `linux-cp` for XFRM

--- a/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From 99cda14db43cc67345bb970ecb78891c1073580e Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Thu, 6 Mar 2025 16:27:51 +0200
-Subject: [PATCH 14/22] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 14/24] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit c784244ca4092210ea74fcff1ec7c1a7d633e2ff.

--- a/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From f0fb2180a6ede48a3ef83c951e8c4e321eabd079 Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 15/22] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 15/24] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:

--- a/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From af8cc793670b14b177a13e9fb7f305ac9cce0ec7 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 18 Mar 2025 21:32:51 +0200
-Subject: [PATCH 16/22] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 16/24] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit 5583626fe1a9d11cffb8f759c996e341b7e54a7b.

--- a/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From 76436e797f22e2e3160d044bdd18ff83154fec3e Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 17/22] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 17/24] linux-cp: Added routing for prefixes with no paths
  available
 
 Fixed GRE crashes in IPv4 and IPv6 FIB.

--- a/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
+++ b/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
@@ -1,7 +1,7 @@
 From 46a6d61368157eb7fb7bf382e3fda9776c5a9a42 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 15 May 2025 17:18:48 +0300
-Subject: [PATCH 18/22] pppoe. Automated session management. (#12)
+Subject: [PATCH 18/24] pppoe. Automated session management. (#12)
 
 Purpose of Changes:
 Automate PPPoE session management by sniffing LCP, IPCP and PADT control frames.

--- a/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
+++ b/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
@@ -1,7 +1,7 @@
 From f8c35e9dc43b36c4469a7586675e74a922af3d58 Mon Sep 17 00:00:00 2001
 From: Andrii Melnychenko <a.melnychenko@vyos.io>
 Date: Thu, 10 Jul 2025 17:42:44 +0200
-Subject: [PATCH 19/22] pppoe: Added option "enable-pass-nd-and-dhcpv6"
+Subject: [PATCH 19/24] pppoe: Added option "enable-pass-nd-and-dhcpv6"
 
 This option would allow to pass ICMPv6 sl & ra and
 UDP-DHCPv6 packets to the PPPoE control plane.

--- a/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
+++ b/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
@@ -1,7 +1,7 @@
 From 9960334b856d1d88ee66ad7a4f7b2949f20ae93a Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 29 Jul 2025 17:39:29 +0300
-Subject: [PATCH 20/22] linux-cp: fix multicast route updates on address
+Subject: [PATCH 20/24] linux-cp: fix multicast route updates on address
  add/del
 
 Ensure multicast routes are only added when the first IPv4 address is configured on an interface,

--- a/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
+++ b/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
@@ -1,7 +1,7 @@
 From b01e1da6fc46a1ccda873b8ca3603ac81fdffd63 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Fri, 1 Aug 2025 17:16:28 +0300
-Subject: [PATCH 21/22] vyos: linux-cp: xfrm: Updated XFRM features for
+Subject: [PATCH 21/24] vyos: linux-cp: xfrm: Updated XFRM features for
  compatibility with VPP 25.06
 
 - Updated headers for `file_main` (as per 2fa70d66482adb21178bad9ebf0d748358cd416e)

--- a/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
+++ b/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
@@ -1,7 +1,7 @@
 From cfb1217a7954404891fe53c8aaa411ef9b142034 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 28 Aug 2025 12:34:32 +0300
-Subject: [PATCH 22/22] ipsec: Improve tunnel mode detection in ESP decrypt
+Subject: [PATCH 22/24] ipsec: Improve tunnel mode detection in ESP decrypt
  post-crypto (#24)
 
 Type: fix

--- a/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
+++ b/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
@@ -1,0 +1,94 @@
+From a0dd2889dd2554c4ebb83b92abaf23f768aa4621 Mon Sep 17 00:00:00 2001
+From: Denys Haryachyy <garyachy@users.noreply.github.com>
+Date: Thu, 18 Sep 2025 13:53:42 +0300
+Subject: [PATCH 23/24] linux-cp: T7775: Add AEAD (RFC4106 AES-GCM) support in
+ xfrm SA handling (#26)
+
+Type: fix
+
+- Parse AEAD parameters via libnl in nl_xfrm_sa_add() using xfrmnl_sa_get_aead_params() with fallback to legacy enc+auth.
+- Map AEAD to VPP by setting AES-GCM crypto alg and integ_alg to IPSEC_INTEG_ALG_NONE; honor AEAD ICV length.
+---
+ src/plugins/linux-cp/lcp_ipsec.c | 49 +++++++++++++++++++++-----------
+ 1 file changed, 33 insertions(+), 16 deletions(-)
+
+diff --git a/src/plugins/linux-cp/lcp_ipsec.c b/src/plugins/linux-cp/lcp_ipsec.c
+index cc3f327c7..c3a6362d4 100644
+--- a/src/plugins/linux-cp/lcp_ipsec.c
++++ b/src/plugins/linux-cp/lcp_ipsec.c
+@@ -882,11 +882,13 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+   ipsec_sa_flags_t flags = IPSEC_SA_FLAG_NONE;
+   char key[IPSEC_KEY_MAX_LEN], auth_key[IPSEC_KEY_MAX_LEN];
+   char alg_name[ALGO_NAME], auth_alg_name[ALGO_NAME];
++  char aead_alg_name[ALGO_NAME];
+   struct nl_addr *dst = xfrmnl_sa_get_daddr (sa);
+   struct nl_addr *src = xfrmnl_sa_get_saddr (sa);
+   unsigned int udp_src, udp_dst, encap_type;
+   sa_life_limits_t *life = NULL, lifetime;
+   unsigned int key_len, auth_key_len;
++  unsigned int aead_icv_len = 0, aead_key_len = 0;
+   ipsec_key_t ck = { 0 }, ik = { 0 };
+   u32 spi = xfrmnl_sa_get_spi (sa);
+   struct nl_addr *encap_oa = NULL;
+@@ -951,27 +953,42 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+     (50 == xfrmnl_sa_get_proto (sa)) ? IPSEC_PROTOCOL_ESP : IPSEC_PROTOCOL_AH;
+   ip_family = xfrmnl_sa_get_family (sa);
+ 
+-  if (-1 == xfrmnl_sa_get_crypto_params (sa, alg_name, &key_len, key))
++  if (0 == xfrmnl_sa_get_aead_params (sa, aead_alg_name, &aead_icv_len,
++				      &aead_key_len, key))
+     {
+-      NL_XFRM_ERR ("crypto param extraction failed");
+-      goto error;
++      clib_memset (alg_name, 0, sizeof (alg_name));
++      clib_strncpy (alg_name, aead_alg_name, sizeof (alg_name) - 1);
++      /* aead_key_len is cipher key bits; ip xfrm provides key||salt.
++       * Represent total bits here so downstream salt extraction works. */
++      key_len = aead_key_len + (GCM_SALT_SIZE * 8);
++      /* No separate integrity algorithm when AEAD is used */
++      integ_alg = IPSEC_INTEG_ALG_NONE;
++      auth_key_len = 0;
+     }
+-  if (-1 == xfrmnl_sa_get_auth_params (sa, auth_alg_name, &auth_key_len, NULL,
+-				       auth_key))
++  else
+     {
+-      NL_XFRM_ERR ("auth param extraction failed");
+-      goto error;
+-    }
++      if (-1 == xfrmnl_sa_get_crypto_params (sa, alg_name, &key_len, key))
++	{
++	  NL_XFRM_ERR ("crypto param extraction failed");
++	  goto error;
++	}
++      if (-1 == xfrmnl_sa_get_auth_params (sa, auth_alg_name, &auth_key_len,
++					   NULL, auth_key))
++	{
++	  NL_XFRM_ERR ("auth param extraction failed");
++	  goto error;
++	}
+ 
+-  get_auth_algo (auth_alg_name, auth_key_len, &integ_alg);
+-  if (integ_alg == IPSEC_INTEG_N_ALG)
+-    {
+-      NL_XFRM_ERR ("Invalid/Unsupported integ algo: %s keylen: %u",
+-		   auth_alg_name, auth_key_len);
+-      goto error;
++      get_auth_algo (auth_alg_name, auth_key_len, &integ_alg);
++      if (integ_alg == IPSEC_INTEG_N_ALG)
++	{
++	  NL_XFRM_ERR ("Invalid/Unsupported integ algo: %s keylen: %u",
++		       auth_alg_name, auth_key_len);
++	  goto error;
++	}
++      ik.len = auth_key_len / 8;
++      clib_memcpy_fast (ik.data, (u8 *) auth_key, (auth_key_len / 8));
+     }
+-  ik.len = auth_key_len / 8;
+-  clib_memcpy_fast (ik.data, (u8 *) auth_key, (auth_key_len / 8));
+ 
+   get_crypto_algo (alg_name, key_len, &crypto_alg);
+   if (crypto_alg == IPSEC_CRYPTO_N_ALG)
+-- 
+2.39.5
+

--- a/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
+++ b/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
@@ -1,0 +1,41 @@
+From c726229ecb073a456dcee38116909b01b47456ae Mon Sep 17 00:00:00 2001
+From: Denys Haryachyy <garyachy@users.noreply.github.com>
+Date: Thu, 18 Sep 2025 17:11:11 +0300
+Subject: [PATCH 24/24] linux-cp: T7770: open XFRM netlink socket at config
+ time. (#25)
+
+Type: fix
+
+Ensures XFRM netlink socket is opened only after explicit config is provided.
+---
+ src/plugins/linux-cp/lcp_xfrm_nl.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/plugins/linux-cp/lcp_xfrm_nl.c b/src/plugins/linux-cp/lcp_xfrm_nl.c
+index 87092ad71..9c5bb88c6 100644
+--- a/src/plugins/linux-cp/lcp_xfrm_nl.c
++++ b/src/plugins/linux-cp/lcp_xfrm_nl.c
+@@ -558,6 +558,10 @@ lcp_xfrm_itf_pair_config (vlib_main_t *vm, unformat_input_t *input)
+     return clib_error_return (
+       0, "enable-route-mode-ipsec configuration is missing");
+ 
++  lcp_xfrm_nl_open_socket ();
++  vlib_process_signal_event (vlib_get_main (),
++			     ipsec_xfrm_expire_process_node.index, 0, 0);
++
+   return NULL;
+ }
+ 
+@@ -658,9 +662,6 @@ lcp_nl_xfrm_init (vlib_main_t *vm)
+   nm->clib_file_index = ~0;
+   nm->nl_logger = vlib_log_register_class ("nl", "xfrm");
+ 
+-  lcp_xfrm_nl_open_socket ();
+-  vlib_process_signal_event (vlib_get_main (),
+-			     ipsec_xfrm_expire_process_node.index, 0, 0);
+   return NULL;
+ }
+ 
+-- 
+2.39.5
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Add AEAD (RFC4106 AES-GCM) support in xfrm SA handling
- Ensures XFRM netlink socket is opened only after explicit config is provided

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Add IPsec VPP patches

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7770
 * https://vyos.dev/T7775

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
