### PR TITLE
T7775: Add fix AES-GCM-256 misidentification

### DIFF
--- a/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
+++ b/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
@@ -1,7 +1,7 @@
 From a3240c47714ae9ed447581c3557983630bb5f825 Mon Sep 17 00:00:00 2001
 From: Aakash <saakashkumar@marvell.com>
 Date: Mon, 1 Aug 2022 04:59:02 -0400
-Subject: [PATCH 01/25] linux-cp: add support for xfrm netlink notifcation
+Subject: [PATCH 01/26] linux-cp: add support for xfrm netlink notifcation
 
 This patch contains changes to add support for handlng xfrm
 notifications in linux-cp plugin.

--- a/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
+++ b/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
@@ -1,7 +1,7 @@
 From e238d4e62e66ed9a9e01425a844d57cc33ec316e Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Tue, 6 Feb 2024 23:23:14 +0530
-Subject: [PATCH 02/25] linux-cp: update code to support api proto changes
+Subject: [PATCH 02/26] linux-cp: update code to support api proto changes
 
 Type: fix
 

--- a/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
+++ b/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
@@ -1,7 +1,7 @@
 From 70286cf59119cc1c122d449ee3fd678646ae1b40 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 5 Dec 2023 18:25:33 +0000
-Subject: [PATCH 03/25] linux-cp: add ipsec interface support for xfrm
+Subject: [PATCH 03/26] linux-cp: add ipsec interface support for xfrm
 
 This patch adds ipsec interface support for strongswan
 based SA configuration.

--- a/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
+++ b/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
@@ -1,7 +1,7 @@
 From 0a6768dea23e4bf4621dac89b166b869f54cc53f Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Wed, 7 Feb 2024 11:58:17 +0530
-Subject: [PATCH 04/25] linux-cp: initialize sw_if_index variable
+Subject: [PATCH 04/26] linux-cp: initialize sw_if_index variable
 
 Type: fix
 

--- a/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
+++ b/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
@@ -1,7 +1,7 @@
 From 33348f8e70e26c3fa93ca921cafef5e9af85337c Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Sun, 24 Mar 2024 08:36:48 +0000
-Subject: [PATCH 05/25] linux-cp: add readme for xfrm implementation
+Subject: [PATCH 05/26] linux-cp: add readme for xfrm implementation
 
 This patch adds REAMDE for XFRM changes design and startup.conf
 configuration details.

--- a/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
+++ b/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
@@ -1,7 +1,7 @@
 From adff1ecb857315e7d3e735efe31dc9b322183732 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 27 Aug 2024 17:29:30 +0000
-Subject: [PATCH 06/25] linux-cp: fix esn and anti-replay issue
+Subject: [PATCH 06/26] linux-cp: fix esn and anti-replay issue
 
 This patch enables anti-replay when ESN is enabled on a Security
 Association (SA) configured via strongSwan.

--- a/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
+++ b/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
@@ -1,7 +1,7 @@
 From e5d9989fe860fd394d131c791c3e74bd8952c230 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 1 Oct 2024 15:06:41 +0000
-Subject: [PATCH 07/25] linux-cp: fix ipsec policy incorrect protocol type
+Subject: [PATCH 07/26] linux-cp: fix ipsec policy incorrect protocol type
 
 This patch changes protocol type 0 to IPSEC_POLICY_PROTOCOL_ANY to
 allow any transport protocol for protect/bypass.

--- a/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
+++ b/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 56275b6a0dbe20b8eb77a16b6525a34ab71b33ca Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Wed, 12 Feb 2025 12:29:57 +0200
-Subject: [PATCH 08/25] linux-cp: Added build dependency for XFRM
+Subject: [PATCH 08/26] linux-cp: Added build dependency for XFRM
 
 Added `libnl-xfrm-3-200` to build dependencies to make build
 `linux-cp` with XFRM possible.

--- a/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From a5f3779078cd93cfc821a23c681af68d1a3a39cf Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 09/25] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 09/26] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:

--- a/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
+++ b/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
@@ -1,7 +1,7 @@
 From d87a33a4dd33f04dce319a1e410bc811808fb7b1 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 24 Jul 2024 08:35:25 +0000
-Subject: [PATCH 10/25] Resync ip fib with Linux state.
+Subject: [PATCH 10/26] Resync ip fib with Linux state.
 
 A new CLI and API file option is available:
 

--- a/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
+++ b/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
@@ -1,7 +1,7 @@
 From 759521ff07dcfb69a09d432e943319a8422ee47c Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 29 Jan 2025 11:57:01 +0200
-Subject: [PATCH 11/25] LCP: Improved lcp resync CLI and API to wait until
+Subject: [PATCH 11/26] LCP: Improved lcp resync CLI and API to wait until
  Netlink sync is finished.
 
 (cherry picked from commit b19375e7e42023a5cdca84f259036574ccd9da77)

--- a/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
+++ b/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
@@ -1,7 +1,7 @@
 From 99f5622c6945c0055e1a3dea4cd925bee1fecf31 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Tue, 11 Feb 2025 20:33:46 +0200
-Subject: [PATCH 12/25] build: Fixed compatibility with build on Debian 12
+Subject: [PATCH 12/26] build: Fixed compatibility with build on Debian 12
 
 (cherry picked from commit ca7d5bcd381edb68e9d4ae6ffa915bda4d2c1adf)
 ---

--- a/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
+++ b/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 4958c7a4553d03532032c20932f5ab5905bff904 Mon Sep 17 00:00:00 2001
 From: Viacheslav Hletenko <v.gletenko@vyos.io>
 Date: Thu, 13 Feb 2025 11:37:36 +0000
-Subject: [PATCH 13/25] linux-cp: Added build dependency libunwind8 for XFRM
+Subject: [PATCH 13/26] linux-cp: Added build dependency libunwind8 for XFRM
 
 Added `libunwind8` to build dependencies required by
 `linux-cp` for XFRM

--- a/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From 99cda14db43cc67345bb970ecb78891c1073580e Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Thu, 6 Mar 2025 16:27:51 +0200
-Subject: [PATCH 14/25] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 14/26] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit c784244ca4092210ea74fcff1ec7c1a7d633e2ff.

--- a/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From f0fb2180a6ede48a3ef83c951e8c4e321eabd079 Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 15/25] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 15/26] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:

--- a/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From af8cc793670b14b177a13e9fb7f305ac9cce0ec7 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 18 Mar 2025 21:32:51 +0200
-Subject: [PATCH 16/25] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 16/26] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit 5583626fe1a9d11cffb8f759c996e341b7e54a7b.

--- a/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From 76436e797f22e2e3160d044bdd18ff83154fec3e Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 17/25] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 17/26] linux-cp: Added routing for prefixes with no paths
  available
 
 Fixed GRE crashes in IPv4 and IPv6 FIB.

--- a/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
+++ b/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
@@ -1,7 +1,7 @@
 From 46a6d61368157eb7fb7bf382e3fda9776c5a9a42 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 15 May 2025 17:18:48 +0300
-Subject: [PATCH 18/25] pppoe. Automated session management. (#12)
+Subject: [PATCH 18/26] pppoe. Automated session management. (#12)
 
 Purpose of Changes:
 Automate PPPoE session management by sniffing LCP, IPCP and PADT control frames.

--- a/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
+++ b/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
@@ -1,7 +1,7 @@
 From f8c35e9dc43b36c4469a7586675e74a922af3d58 Mon Sep 17 00:00:00 2001
 From: Andrii Melnychenko <a.melnychenko@vyos.io>
 Date: Thu, 10 Jul 2025 17:42:44 +0200
-Subject: [PATCH 19/25] pppoe: Added option "enable-pass-nd-and-dhcpv6"
+Subject: [PATCH 19/26] pppoe: Added option "enable-pass-nd-and-dhcpv6"
 
 This option would allow to pass ICMPv6 sl & ra and
 UDP-DHCPv6 packets to the PPPoE control plane.

--- a/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
+++ b/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
@@ -1,7 +1,7 @@
 From 9960334b856d1d88ee66ad7a4f7b2949f20ae93a Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 29 Jul 2025 17:39:29 +0300
-Subject: [PATCH 20/25] linux-cp: fix multicast route updates on address
+Subject: [PATCH 20/26] linux-cp: fix multicast route updates on address
  add/del
 
 Ensure multicast routes are only added when the first IPv4 address is configured on an interface,

--- a/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
+++ b/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
@@ -1,7 +1,7 @@
 From b01e1da6fc46a1ccda873b8ca3603ac81fdffd63 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Fri, 1 Aug 2025 17:16:28 +0300
-Subject: [PATCH 21/25] vyos: linux-cp: xfrm: Updated XFRM features for
+Subject: [PATCH 21/26] vyos: linux-cp: xfrm: Updated XFRM features for
  compatibility with VPP 25.06
 
 - Updated headers for `file_main` (as per 2fa70d66482adb21178bad9ebf0d748358cd416e)

--- a/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
+++ b/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
@@ -1,7 +1,7 @@
 From cfb1217a7954404891fe53c8aaa411ef9b142034 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 28 Aug 2025 12:34:32 +0300
-Subject: [PATCH 22/25] ipsec: Improve tunnel mode detection in ESP decrypt
+Subject: [PATCH 22/26] ipsec: Improve tunnel mode detection in ESP decrypt
  post-crypto (#24)
 
 Type: fix

--- a/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
+++ b/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
@@ -1,7 +1,7 @@
 From a0dd2889dd2554c4ebb83b92abaf23f768aa4621 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 18 Sep 2025 13:53:42 +0300
-Subject: [PATCH 23/25] linux-cp: T7775: Add AEAD (RFC4106 AES-GCM) support in
+Subject: [PATCH 23/26] linux-cp: T7775: Add AEAD (RFC4106 AES-GCM) support in
  xfrm SA handling (#26)
 
 Type: fix

--- a/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
+++ b/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
@@ -1,7 +1,7 @@
 From c726229ecb073a456dcee38116909b01b47456ae Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 18 Sep 2025 17:11:11 +0300
-Subject: [PATCH 24/25] linux-cp: T7770: open XFRM netlink socket at config
+Subject: [PATCH 24/26] linux-cp: T7770: open XFRM netlink socket at config
  time. (#25)
 
 Type: fix

--- a/patches/vpp/0025-policer-Added-features-for-unicast-multicast-arc.-29.patch
+++ b/patches/vpp/0025-policer-Added-features-for-unicast-multicast-arc.-29.patch
@@ -1,7 +1,7 @@
 From 7b605e618d34710680d0c46d93c3b1824398a1f0 Mon Sep 17 00:00:00 2001
 From: Fullroot <51375681+AndriiFullroot@users.noreply.github.com>
 Date: Thu, 9 Oct 2025 16:19:38 +0200
-Subject: [PATCH 25/25] policer: Added features for unicast/multicast arc.
+Subject: [PATCH 25/26] policer: Added features for unicast/multicast arc.
  (#29)
 
 For the PPPoE session, the input policer would not work

--- a/patches/vpp/0026-linux-cp-T7775-fix-AES-GCM-256-misidentification-30.patch
+++ b/patches/vpp/0026-linux-cp-T7775-fix-AES-GCM-256-misidentification-30.patch
@@ -1,0 +1,151 @@
+From d3bf1f02365d9b6d7680a2366927d421a66bb2e5 Mon Sep 17 00:00:00 2001
+From: Denys Haryachyy <garyachy@users.noreply.github.com>
+Date: Thu, 23 Oct 2025 17:25:11 +0300
+Subject: [PATCH 26/26] linux-cp: T7775: fix AES-GCM-256 misidentification
+ (#30)
+
+VPP was incorrectly identifying AES-GCM-256 IPsec SAs as AES-GCM-128,
+causing cryptographic key material mismatch with peer implementations
+like StrongSwan. This resulted in encryption/decryption failures and
+non-functional IPsec tunnels.
+
+Root cause: The libnl xfrmnl_sa_get_aead_params() function reports only
+the cipher key length (e.g., 128 bits for what should be AES-GCM-256)
+in the aead_key_len parameter, while extracting the full key material
+including padding into the key buffer (46 bytes instead of expected 36).
+---
+ src/plugins/linux-cp/lcp_ipsec.c | 90 ++++++++++++++++++++++++++------
+ 1 file changed, 75 insertions(+), 15 deletions(-)
+
+diff --git a/src/plugins/linux-cp/lcp_ipsec.c b/src/plugins/linux-cp/lcp_ipsec.c
+index c3a6362d4..6eb69984b 100644
+--- a/src/plugins/linux-cp/lcp_ipsec.c
++++ b/src/plugins/linux-cp/lcp_ipsec.c
+@@ -28,6 +28,70 @@
+ /* size in bytes */
+ #define GCM_SALT_SIZE 4
+ 
++/*
++ * Wrapper around xfrmnl_sa_get_aead_params that normalizes key length
++ * for GCM algorithms to handle libnl padding issues.
++ */
++static int
++lcp_xfrm_get_aead_params_normalized (struct xfrmnl_sa *sa, char *alg_name,
++				     u32 *aead_icv_len, u32 *aead_key_len,
++				     u32 *normalized_key_len, void *key)
++{
++  int ret =
++    xfrmnl_sa_get_aead_params (sa, alg_name, aead_icv_len, aead_key_len, key);
++  if (ret != 0)
++    return ret;
++
++  /* For GCM algorithms, libnl reports only the cipher key length in
++   * aead_key_len but extracts full key material including extra padding.
++   * We need to detect the actual key size by checking key material layout:
++   * - AES-GCM-128: 16-byte key + 4-byte salt (byte 16-19 = salt)
++   * - AES-GCM-192: 24-byte key + 4-byte salt (byte 24-27 = salt)
++   * - AES-GCM-256: 32-byte key + 4-byte salt (byte 32-35 = salt)
++   */
++  if (((u8 *) key)[32] != 0)
++    {
++      /* AES-GCM-256: 32-byte cipher key + 4-byte salt = 288 bits */
++      *normalized_key_len = 36 * 8;
++    }
++  else if (((u8 *) key)[24] != 0)
++    {
++      /* AES-GCM-192: 24-byte cipher key + 4-byte salt = 224 bits */
++      *normalized_key_len = 28 * 8;
++    }
++  else
++    {
++      /* AES-GCM-128: 16-byte cipher key + 4-byte salt = 160 bits */
++      *normalized_key_len = 20 * 8;
++    }
++
++  return 0;
++}
++
++/*
++ * Extract cipher key and salt for GCM algorithms based on detected variant.
++ */
++static void
++lcp_xfrm_extract_gcm_key_and_salt (ipsec_crypto_alg_t crypto_alg, void *key,
++				   ipsec_key_t *ck, u32 *salt)
++{
++  /* Determine correct cipher key size based on detected algorithm */
++  u32 cipher_key_bytes;
++  if (crypto_alg == IPSEC_CRYPTO_ALG_AES_GCM_128)
++    cipher_key_bytes = 16;
++  else if (crypto_alg == IPSEC_CRYPTO_ALG_AES_GCM_192)
++    cipher_key_bytes = 24;
++  else if (crypto_alg == IPSEC_CRYPTO_ALG_AES_GCM_256)
++    cipher_key_bytes = 32;
++  else
++    cipher_key_bytes = 16; /* fallback */
++
++  /* Extract cipher key and salt from Linux XFRM key material */
++  ck->len = cipher_key_bytes;
++  clib_memcpy_fast (ck->data, (u8 *) key, ck->len);
++  clib_memcpy_fast (salt, ((u8 *) key) + ck->len, GCM_SALT_SIZE);
++}
++
+ #define cpu_to_be(x, bits)                                                    \
+   if ((bits) == 16)                                                           \
+     x = clib_host_to_net_u16 (x);                                             \
+@@ -953,14 +1017,12 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+     (50 == xfrmnl_sa_get_proto (sa)) ? IPSEC_PROTOCOL_ESP : IPSEC_PROTOCOL_AH;
+   ip_family = xfrmnl_sa_get_family (sa);
+ 
+-  if (0 == xfrmnl_sa_get_aead_params (sa, aead_alg_name, &aead_icv_len,
+-				      &aead_key_len, key))
++  if (0 == lcp_xfrm_get_aead_params_normalized (
++	     sa, aead_alg_name, &aead_icv_len, &aead_key_len, &key_len, key))
+     {
+       clib_memset (alg_name, 0, sizeof (alg_name));
+       clib_strncpy (alg_name, aead_alg_name, sizeof (alg_name) - 1);
+-      /* aead_key_len is cipher key bits; ip xfrm provides key||salt.
+-       * Represent total bits here so downstream salt extraction works. */
+-      key_len = aead_key_len + (GCM_SALT_SIZE * 8);
++
+       /* No separate integrity algorithm when AEAD is used */
+       integ_alg = IPSEC_INTEG_ALG_NONE;
+       auth_key_len = 0;
+@@ -991,6 +1053,7 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+     }
+ 
+   get_crypto_algo (alg_name, key_len, &crypto_alg);
++
+   if (crypto_alg == IPSEC_CRYPTO_N_ALG)
+     {
+       NL_XFRM_ERR ("Invalid/Unsupported crypto algo: %s keylen: %u", alg_name,
+@@ -999,20 +1062,17 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+     }
+ 
+   /*
+-   * Key_len/key here includes salt size/value. As per rfc5282
+-   * GCM salt size will be 4B which will be after cipher key
++   * Process crypto key and extract salt for GCM algorithms.
++   * Use proper key material size based on detected algorithm.
+    */
+   if (IPSEC_CRYPTO_ALG_IS_GCM (crypto_alg))
++    lcp_xfrm_extract_gcm_key_and_salt (crypto_alg, key, &ck, &salt);
++  else
+     {
+-      key_len -= GCM_SALT_SIZE * 8;
+-      clib_memcpy_fast (&salt, ((u8 *) key) + (key_len / 8), GCM_SALT_SIZE);
++      /* Non-GCM: use key as-is */
++      ck.len = key_len / 8;
++      clib_memcpy_fast (ck.data, (u8 *) key, ck.len);
+     }
+-  /*
+-   * Else for CCM if supported, salt size would be 3B and needs
+-   * to be handled here accordingly
+-   */
+-  ck.len = key_len / 8;
+-  clib_memcpy_fast (ck.data, (u8 *) key, (key_len / 8));
+ 
+   is_ipv6 = (ip_family == AF_INET) ? 0 : 1;
+ 
+-- 
+2.39.5
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VPP was incorrectly identifying AES-GCM-256 IPsec SAs as AES-GCM-128,
causing a cryptographic key material mismatch with peer implementations
like StrongSwan. This resulted in encryption/decryption failures and
non-functional IPsec tunnels.

Root cause: The libnl xfrmnl_sa_get_aead_params() function reports only
the cipher key length (e.g., 128 bits for what should be AES-GCM-256)
in the aead_key_len parameter, while extracting the full key material
including padding into the key buffer (46 bytes instead of the expected 36).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7775

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
