### PR TITLE
T7970: VPP add optional systemd notify support for service readiness

### DIFF
--- a/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
+++ b/patches/vpp/0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch
@@ -1,7 +1,7 @@
 From a3240c47714ae9ed447581c3557983630bb5f825 Mon Sep 17 00:00:00 2001
 From: Aakash <saakashkumar@marvell.com>
 Date: Mon, 1 Aug 2022 04:59:02 -0400
-Subject: [PATCH 01/28] linux-cp: add support for xfrm netlink notifcation
+Subject: [PATCH 01/29] linux-cp: add support for xfrm netlink notifcation
 
 This patch contains changes to add support for handlng xfrm
 notifications in linux-cp plugin.
@@ -2473,5 +2473,5 @@ index 000000000..21497cde9
 + * End:
 + */
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
+++ b/patches/vpp/0002-linux-cp-update-code-to-support-api-proto-changes.patch
@@ -1,7 +1,7 @@
 From e238d4e62e66ed9a9e01425a844d57cc33ec316e Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Tue, 6 Feb 2024 23:23:14 +0530
-Subject: [PATCH 02/28] linux-cp: update code to support api proto changes
+Subject: [PATCH 02/29] linux-cp: update code to support api proto changes
 
 Type: fix
 
@@ -28,5 +28,5 @@ index 5b3a46058..3e5904454 100644
      {
        NL_XFRM_ERR ("ipsec sa add %x failure(err: %d) %U -> %U", id, rv,
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
+++ b/patches/vpp/0003-linux-cp-add-ipsec-interface-support-for-xfrm.patch
@@ -1,7 +1,7 @@
 From 70286cf59119cc1c122d449ee3fd678646ae1b40 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 5 Dec 2023 18:25:33 +0000
-Subject: [PATCH 03/28] linux-cp: add ipsec interface support for xfrm
+Subject: [PATCH 03/29] linux-cp: add ipsec interface support for xfrm
 
 This patch adds ipsec interface support for strongswan
 based SA configuration.
@@ -306,5 +306,5 @@ index 21497cde9..4eabf40e6 100644
  }
  
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
+++ b/patches/vpp/0004-linux-cp-initialize-sw_if_index-variable.patch
@@ -1,7 +1,7 @@
 From 0a6768dea23e4bf4621dac89b166b869f54cc53f Mon Sep 17 00:00:00 2001
 From: Kommula Shiva Shankar <kshankar@marvell.com>
 Date: Wed, 7 Feb 2024 11:58:17 +0530
-Subject: [PATCH 04/28] linux-cp: initialize sw_if_index variable
+Subject: [PATCH 04/29] linux-cp: initialize sw_if_index variable
 
 Type: fix
 
@@ -28,5 +28,5 @@ index 79194c226..fe83a948a 100644
    u8 *s = NULL;
    u8 instance = xfrmnl_sa_get_reqid (sa);
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
+++ b/patches/vpp/0005-linux-cp-add-readme-for-xfrm-implementation.patch
@@ -1,7 +1,7 @@
 From 33348f8e70e26c3fa93ca921cafef5e9af85337c Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Sun, 24 Mar 2024 08:36:48 +0000
-Subject: [PATCH 05/28] linux-cp: add readme for xfrm implementation
+Subject: [PATCH 05/29] linux-cp: add readme for xfrm implementation
 
 This patch adds REAMDE for XFRM changes design and startup.conf
 configuration details.
@@ -199,5 +199,5 @@ index 000000000..9e63646dd
 + nl-batch-delay-ms <>
 +}
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
+++ b/patches/vpp/0006-linux-cp-fix-esn-and-anti-replay-issue.patch
@@ -1,7 +1,7 @@
 From adff1ecb857315e7d3e735efe31dc9b322183732 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 27 Aug 2024 17:29:30 +0000
-Subject: [PATCH 06/28] linux-cp: fix esn and anti-replay issue
+Subject: [PATCH 06/29] linux-cp: fix esn and anti-replay issue
 
 This patch enables anti-replay when ESN is enabled on a Security
 Association (SA) configured via strongSwan.
@@ -36,5 +36,5 @@ index fe83a948a..c847e699f 100644
    /*
     * Kernel SA XFRM doesnt have a flag for AR config. So a non-zero
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
+++ b/patches/vpp/0007-linux-cp-fix-ipsec-policy-incorrect-protocol-type.patch
@@ -1,7 +1,7 @@
 From e5d9989fe860fd394d131c791c3e74bd8952c230 Mon Sep 17 00:00:00 2001
 From: Bheemappa Agasimundin <bagasimundin@marvell.com>
 Date: Tue, 1 Oct 2024 15:06:41 +0000
-Subject: [PATCH 07/28] linux-cp: fix ipsec policy incorrect protocol type
+Subject: [PATCH 07/29] linux-cp: fix ipsec policy incorrect protocol type
 
 This patch changes protocol type 0 to IPSEC_POLICY_PROTOCOL_ANY to
 allow any transport protocol for protect/bypass.
@@ -51,5 +51,5 @@ index c847e699f..ff6e79649 100644
  
    lcp_xfrm_mk_ipaddr (sel_dst, &sel_daddr);
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
+++ b/patches/vpp/0008-linux-cp-Added-build-dependency-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 56275b6a0dbe20b8eb77a16b6525a34ab71b33ca Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Wed, 12 Feb 2025 12:29:57 +0200
-Subject: [PATCH 08/28] linux-cp: Added build dependency for XFRM
+Subject: [PATCH 08/29] linux-cp: Added build dependency for XFRM
 
 Added `libnl-xfrm-3-200` to build dependencies to make build
 `linux-cp` with XFRM possible.
@@ -24,5 +24,5 @@ index 3cdaf2778..19dafb7c6 100644
  LIBFFI=libffi6 # works on all but 20.04 and debian-testing
  ifeq ($(OS_VERSION_ID),24.04)
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0009-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From a5f3779078cd93cfc821a23c681af68d1a3a39cf Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 09/28] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 09/29] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:
@@ -182,5 +182,5 @@ index 27f53357a..2cb99a734 100644
         (ip6_address_is_multicast (&pfx.fp_addr.ip6) ||
  	ip6_address_is_link_local_unicast (&pfx.fp_addr.ip6))))
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
+++ b/patches/vpp/0010-Resync-ip-fib-with-Linux-state.patch
@@ -1,7 +1,7 @@
 From d87a33a4dd33f04dce319a1e410bc811808fb7b1 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 24 Jul 2024 08:35:25 +0000
-Subject: [PATCH 10/28] Resync ip fib with Linux state.
+Subject: [PATCH 10/29] Resync ip fib with Linux state.
 
 A new CLI and API file option is available:
 
@@ -197,5 +197,5 @@ index 55d2ea542..5ac6ae273 100644
  	   * reduce the number of failed attempts that stall the main thread by
  	   * waiting out the notification storm
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
+++ b/patches/vpp/0011-LCP-Improved-lcp-resync-CLI-and-API-to-wait-until-Ne.patch
@@ -1,7 +1,7 @@
 From 759521ff07dcfb69a09d432e943319a8422ee47c Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Wed, 29 Jan 2025 11:57:01 +0200
-Subject: [PATCH 11/28] LCP: Improved lcp resync CLI and API to wait until
+Subject: [PATCH 11/29] LCP: Improved lcp resync CLI and API to wait until
  Netlink sync is finished.
 
 (cherry picked from commit b19375e7e42023a5cdca84f259036574ccd9da77)
@@ -341,5 +341,5 @@ index 000000000..f9005b6fc
 + * End:
 + */
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
+++ b/patches/vpp/0012-build-Fixed-compatibility-with-build-on-Debian-12.patch
@@ -1,7 +1,7 @@
 From 99f5622c6945c0055e1a3dea4cd925bee1fecf31 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Tue, 11 Feb 2025 20:33:46 +0200
-Subject: [PATCH 12/28] build: Fixed compatibility with build on Debian 12
+Subject: [PATCH 12/29] build: Fixed compatibility with build on Debian 12
 
 (cherry picked from commit ca7d5bcd381edb68e9d4ae6ffa915bda4d2c1adf)
 ---
@@ -21,5 +21,5 @@ index 19dafb7c6..d8f1061d5 100644
  	# TODO: remove once ubuntu 20.04 is deprecated and extras/scripts/checkstyle.sh is upgraded to -15
  	export CLANG_FORMAT_VER=15
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
+++ b/patches/vpp/0013-linux-cp-Added-build-dependency-libunwind8-for-XFRM.patch
@@ -1,7 +1,7 @@
 From 4958c7a4553d03532032c20932f5ab5905bff904 Mon Sep 17 00:00:00 2001
 From: Viacheslav Hletenko <v.gletenko@vyos.io>
 Date: Thu, 13 Feb 2025 11:37:36 +0000
-Subject: [PATCH 13/28] linux-cp: Added build dependency libunwind8 for XFRM
+Subject: [PATCH 13/29] linux-cp: Added build dependency libunwind8 for XFRM
 
 Added `libunwind8` to build dependencies required by
 `linux-cp` for XFRM
@@ -22,5 +22,5 @@ index d8f1061d5..aa54f6089 100644
  LIBFFI=libffi6 # works on all but 20.04 and debian-testing
  ifeq ($(OS_VERSION_ID),24.04)
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0014-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From 99cda14db43cc67345bb970ecb78891c1073580e Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Thu, 6 Mar 2025 16:27:51 +0200
-Subject: [PATCH 14/28] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 14/29] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit c784244ca4092210ea74fcff1ec7c1a7d633e2ff.
@@ -166,5 +166,5 @@ index 2cb99a734..27f53357a 100644
         (ip6_address_is_multicast (&pfx.fp_addr.ip6) ||
  	ip6_address_is_link_local_unicast (&pfx.fp_addr.ip6))))
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0015-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From f0fb2180a6ede48a3ef83c951e8c4e321eabd079 Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 15/28] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 15/29] linux-cp: Added routing for prefixes with no paths
  available
 
 A new CLI and configuration file option is available:
@@ -280,5 +280,5 @@ index 27f53357a..8dbe74cf7 100644
    if (0 != vec_len (np.paths))
      {
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
+++ b/patches/vpp/0016-Revert-linux-cp-Added-routing-for-prefixes-with-no-p.patch
@@ -1,7 +1,7 @@
 From af8cc793670b14b177a13e9fb7f305ac9cce0ec7 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 18 Mar 2025 21:32:51 +0200
-Subject: [PATCH 16/28] Revert "linux-cp: Added routing for prefixes with no
+Subject: [PATCH 16/29] Revert "linux-cp: Added routing for prefixes with no
  paths available"
 
 This reverts commit 5583626fe1a9d11cffb8f759c996e341b7e54a7b.
@@ -244,5 +244,5 @@ index 8dbe74cf7..27f53357a 100644
    if (0 != vec_len (np.paths))
      {
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
+++ b/patches/vpp/0017-linux-cp-Added-routing-for-prefixes-with-no-paths-av.patch
@@ -1,7 +1,7 @@
 From 76436e797f22e2e3160d044bdd18ff83154fec3e Mon Sep 17 00:00:00 2001
 From: zsdc <taras@vyos.io>
 Date: Tue, 23 Jul 2024 20:06:41 +0300
-Subject: [PATCH 17/28] linux-cp: Added routing for prefixes with no paths
+Subject: [PATCH 17/29] linux-cp: Added routing for prefixes with no paths
  available
 
 Fixed GRE crashes in IPv4 and IPv6 FIB.
@@ -360,5 +360,5 @@ index cabefd812..3f8b4aed3 100644
    if (is_receive_dpo)
      {
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
+++ b/patches/vpp/0018-pppoe.-Automated-session-management.-12.patch
@@ -1,7 +1,7 @@
 From 46a6d61368157eb7fb7bf382e3fda9776c5a9a42 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 15 May 2025 17:18:48 +0300
-Subject: [PATCH 18/28] pppoe. Automated session management. (#12)
+Subject: [PATCH 18/29] pppoe. Automated session management. (#12)
 
 Purpose of Changes:
 Automate PPPoE session management by sniffing LCP, IPCP and PADT control frames.
@@ -1384,5 +1384,5 @@ index b2daadba8..ecb8d7f4c 100644
    S (mp);
    W (ret);
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
+++ b/patches/vpp/0019-pppoe-Added-option-enable-pass-nd-and-dhcpv6.patch
@@ -1,7 +1,7 @@
 From f8c35e9dc43b36c4469a7586675e74a922af3d58 Mon Sep 17 00:00:00 2001
 From: Andrii Melnychenko <a.melnychenko@vyos.io>
 Date: Thu, 10 Jul 2025 17:42:44 +0200
-Subject: [PATCH 19/28] pppoe: Added option "enable-pass-nd-and-dhcpv6"
+Subject: [PATCH 19/29] pppoe: Added option "enable-pass-nd-and-dhcpv6"
 
 This option would allow to pass ICMPv6 sl & ra and
 UDP-DHCPv6 packets to the PPPoE control plane.
@@ -95,5 +95,5 @@ index ec5692721..79710392d 100644
  		  vlan0 == 0 ?
  	  	    vlib_buffer_advance(b0, sizeof(*h0))
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
+++ b/patches/vpp/0020-linux-cp-fix-multicast-route-updates-on-address-add-.patch
@@ -1,7 +1,7 @@
 From 9960334b856d1d88ee66ad7a4f7b2949f20ae93a Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@gmail.com>
 Date: Tue, 29 Jul 2025 17:39:29 +0300
-Subject: [PATCH 20/28] linux-cp: fix multicast route updates on address
+Subject: [PATCH 20/29] linux-cp: fix multicast route updates on address
  add/del
 
 Ensure multicast routes are only added when the first IPv4 address is configured on an interface,
@@ -93,5 +93,5 @@ index 490b9fc23..a2a51f079 100644
  
        LCP_ROUTER_DBG ("link-addr: %U %U/%d", format_vnet_sw_if_index_name,
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
+++ b/patches/vpp/0021-vyos-linux-cp-xfrm-Updated-XFRM-features-for-compati.patch
@@ -1,7 +1,7 @@
 From b01e1da6fc46a1ccda873b8ca3603ac81fdffd63 Mon Sep 17 00:00:00 2001
 From: zdc <taras@vyos.io>
 Date: Fri, 1 Aug 2025 17:16:28 +0300
-Subject: [PATCH 21/28] vyos: linux-cp: xfrm: Updated XFRM features for
+Subject: [PATCH 21/29] vyos: linux-cp: xfrm: Updated XFRM features for
  compatibility with VPP 25.06
 
 - Updated headers for `file_main` (as per 2fa70d66482adb21178bad9ebf0d748358cd416e)
@@ -162,5 +162,5 @@ index 4eabf40e6..87092ad71 100644
  #include <vppinfra/linux/netns.h>
  
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
+++ b/patches/vpp/0022-ipsec-Improve-tunnel-mode-detection-in-ESP-decrypt-p.patch
@@ -1,7 +1,7 @@
 From cfb1217a7954404891fe53c8aaa411ef9b142034 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 28 Aug 2025 12:34:32 +0300
-Subject: [PATCH 22/28] ipsec: Improve tunnel mode detection in ESP decrypt
+Subject: [PATCH 22/29] ipsec: Improve tunnel mode detection in ESP decrypt
  post-crypto (#24)
 
 Type: fix
@@ -31,5 +31,5 @@ index 7f7cd5748..102594dbb 100644
  		  const ip4_header_t *ip4;
  
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
+++ b/patches/vpp/0023-linux-cp-T7775-Add-AEAD-RFC4106-AES-GCM-support-in-x.patch
@@ -1,7 +1,7 @@
 From a0dd2889dd2554c4ebb83b92abaf23f768aa4621 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 18 Sep 2025 13:53:42 +0300
-Subject: [PATCH 23/28] linux-cp: T7775: Add AEAD (RFC4106 AES-GCM) support in
+Subject: [PATCH 23/29] linux-cp: T7775: Add AEAD (RFC4106 AES-GCM) support in
  xfrm SA handling (#26)
 
 Type: fix
@@ -90,5 +90,5 @@ index cc3f327c7..c3a6362d4 100644
    get_crypto_algo (alg_name, key_len, &crypto_alg);
    if (crypto_alg == IPSEC_CRYPTO_N_ALG)
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
+++ b/patches/vpp/0024-linux-cp-T7770-open-XFRM-netlink-socket-at-config-ti.patch
@@ -1,7 +1,7 @@
 From c726229ecb073a456dcee38116909b01b47456ae Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 18 Sep 2025 17:11:11 +0300
-Subject: [PATCH 24/28] linux-cp: T7770: open XFRM netlink socket at config
+Subject: [PATCH 24/29] linux-cp: T7770: open XFRM netlink socket at config
  time. (#25)
 
 Type: fix
@@ -37,5 +37,5 @@ index 87092ad71..9c5bb88c6 100644
  }
  
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0025-policer-Added-features-for-unicast-multicast-arc.-29.patch
+++ b/patches/vpp/0025-policer-Added-features-for-unicast-multicast-arc.-29.patch
@@ -1,7 +1,7 @@
 From 7b605e618d34710680d0c46d93c3b1824398a1f0 Mon Sep 17 00:00:00 2001
 From: Fullroot <51375681+AndriiFullroot@users.noreply.github.com>
 Date: Thu, 9 Oct 2025 16:19:38 +0200
-Subject: [PATCH 25/28] policer: Added features for unicast/multicast arc.
+Subject: [PATCH 25/29] policer: Added features for unicast/multicast arc.
  (#29)
 
 For the PPPoE session, the input policer would not work
@@ -50,5 +50,5 @@ index 2d2252d24..37d0977bb 100644
  (vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
  {
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0026-linux-cp-T7775-fix-AES-GCM-256-misidentification-30.patch
+++ b/patches/vpp/0026-linux-cp-T7775-fix-AES-GCM-256-misidentification-30.patch
@@ -1,7 +1,7 @@
 From d3bf1f02365d9b6d7680a2366927d421a66bb2e5 Mon Sep 17 00:00:00 2001
 From: Denys Haryachyy <garyachy@users.noreply.github.com>
 Date: Thu, 23 Oct 2025 17:25:11 +0300
-Subject: [PATCH 26/28] linux-cp: T7775: fix AES-GCM-256 misidentification
+Subject: [PATCH 26/29] linux-cp: T7775: fix AES-GCM-256 misidentification
  (#30)
 
 VPP was incorrectly identifying AES-GCM-256 IPsec SAs as AES-GCM-128,
@@ -147,5 +147,5 @@ index c3a6362d4..6eb69984b 100644
    is_ipv6 = (ip_family == AF_INET) ? 0 : 1;
  
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0027-version-Implement-VyOS-specific-versioning-format-31.patch
+++ b/patches/vpp/0027-version-Implement-VyOS-specific-versioning-format-31.patch
@@ -1,7 +1,7 @@
 From f449680494d7851af849c68bdc4f75cd6d1b9e6d Mon Sep 17 00:00:00 2001
 From: zdc <zdc@users.noreply.github.com>
 Date: Fri, 31 Oct 2025 16:47:41 +0200
-Subject: [PATCH 27/28] version: Implement VyOS-specific versioning format
+Subject: [PATCH 27/29] version: Implement VyOS-specific versioning format
  (#31)
 
 Modify the version script to generate VyOS-specific version strings that include UTC
@@ -45,5 +45,5 @@ index b8748af15..4e517da21 100755
      CMT=$(echo ${vstring} | cut -s -d- -f3,4)
  fi
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0028-DET44-IPFIX-support-for-DET44.-28.patch
+++ b/patches/vpp/0028-DET44-IPFIX-support-for-DET44.-28.patch
@@ -1,7 +1,7 @@
 From d1f8e7951245036b730c4ce9b9d40b54538d80e9 Mon Sep 17 00:00:00 2001
 From: Fullroot <51375681+AndriiFullroot@users.noreply.github.com>
 Date: Mon, 3 Nov 2025 15:06:52 +0100
-Subject: [PATCH 28/28] DET44: IPFIX support for DET44. (#28)
+Subject: [PATCH 28/29] DET44: IPFIX support for DET44. (#28)
 
 Added IPFIX nat event messages to DET44.
 
@@ -239,5 +239,5 @@ index dd89606ff..04e9fbdbc 100644
  	  sum0 = tcp0->checksum;
  	  sum0 = ip_csum_update (sum0, old_addr0.as_u32, new_addr0.as_u32,
 -- 
-2.39.5
+2.39.5 (Apple Git-154)
 

--- a/patches/vpp/0029-vlib-add-optional-systemd-notify-support-for-service.patch
+++ b/patches/vpp/0029-vlib-add-optional-systemd-notify-support-for-service.patch
@@ -1,0 +1,272 @@
+From a3e1cc07bed782b695c1376994a242798ba5c14d Mon Sep 17 00:00:00 2001
+From: zdc <taras@vyos.io>
+Date: Fri, 7 Nov 2025 21:17:20 +0200
+Subject: [PATCH 29/29] vlib: add optional systemd notify support for service
+ readiness
+
+Add optional systemd sd_notify() integration to signal when VPP is
+fully initialized and ready to process packets. This allows systemd
+to properly track VPP startup and manage service dependencies using
+Type=notify service configuration.
+
+Features:
+
+- Build-time optional: disabled by default, enable with
+  -DVPP_ENABLE_SYSTEMD_NOTIFY=ON
+- Runtime optional: requires 'systemd-notify' in unix config section
+- Platform independent: gracefully handles systems without systemd
+- Notification sent after startup configuration is executed, ensuring
+  all plugins and configurations are ready
+
+Implementation:
+
+- CMake option VPP_ENABLE_SYSTEMD_NOTIFY detects and links libsystemd
+- Preprocessor define VLIB_SYSTEMD_NOTIFY_ENABLED for conditional compilation
+- Static function vlib_unix_systemd_notify_ready() in unix/main.c
+- Called from startup_config_process() after config execution completes
+  (or immediately if no startup config file is specified)
+- UNIX_FLAG_SYSTEMD_NOTIFY remains unconditional for ABI stability
+
+Usage:
+
+Install dependencies (if building with systemd support):
+`make VPP_ENABLE_SYSTEMD_NOTIFY=ON install-dep`
+
+Build with systemd support:
+`make VPP_EXTRA_CMAKE_ARGS="-DVPP_ENABLE_SYSTEMD_NOTIFY=ON" pkg-deb`
+
+Enable in startup.conf:
+
+```
+  unix {
+    systemd-notify
+  }
+```
+
+Systemd service file:
+
+```
+[Service]
+Type=notify
+```
+---
+ Makefile                | 10 +++++++++
+ src/pkg/CMakeLists.txt  |  6 +++++
+ src/vlib/CMakeLists.txt | 21 ++++++++++++++++++
+ src/vlib/config.h.in    |  1 +
+ src/vlib/unix/main.c    | 49 +++++++++++++++++++++++++++++++++++++++++
+ src/vlib/unix/unix.h    |  1 +
+ 6 files changed, 88 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index aa54f6089..758e7a9aa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -111,6 +111,11 @@ DEB_DEPENDS += nasm libnuma-dev # for make-ext-deps
+ DEB_DEPENDS += libnl-xfrm-3-200 # for linux-cp XFRM extension
+ DEB_DEPENDS += libunwind8 # for linux-cp XFRM extension
+ 
++# Conditional dependencies based on build options
++ifneq ($(VPP_ENABLE_SYSTEMD_NOTIFY),)
++DEB_DEPENDS += libsystemd-dev
++endif
++
+ LIBFFI=libffi6 # works on all but 20.04 and debian-testing
+ ifeq ($(OS_VERSION_ID),24.04)
+ 	DEB_DEPENDS += libssl-dev
+@@ -169,6 +174,11 @@ RPM_DEPENDS += libnl3-devel libmnl-devel
+ RPM_DEPENDS += nasm
+ RPM_DEPENDS += socat
+ 
++# Conditional dependencies based on build options
++ifneq ($(VPP_ENABLE_SYSTEMD_NOTIFY),)
++RPM_DEPENDS += systemd-devel
++endif
++
+ ifeq ($(OS_ID),fedora)
+ 	RPM_DEPENDS += dnf-utils
+ 	RPM_DEPENDS += subunit subunit-devel
+diff --git a/src/pkg/CMakeLists.txt b/src/pkg/CMakeLists.txt
+index 5fa2826ad..cddffd35b 100644
+--- a/src/pkg/CMakeLists.txt
++++ b/src/pkg/CMakeLists.txt
+@@ -51,6 +51,12 @@ foreach(l ${os_release})
+ endforeach()
+ 
+ set(VPP_DEB_BUILD_DEPENDS "python3-all, python3-setuptools")
++
++# Add systemd build dependency if systemd notify support is enabled
++if(VPP_ENABLE_SYSTEMD_NOTIFY)
++  set(VPP_DEB_BUILD_DEPENDS "${VPP_DEB_BUILD_DEPENDS}, libsystemd-dev")
++endif()
++
+ set(VPP_DEB_WITH_PYTHON2 "no")
+ 
+ foreach(f rules changelog control)
+diff --git a/src/vlib/CMakeLists.txt b/src/vlib/CMakeLists.txt
+index b4fc17751..5f0e87c48 100644
+--- a/src/vlib/CMakeLists.txt
++++ b/src/vlib/CMakeLists.txt
+@@ -12,6 +12,7 @@
+ # limitations under the License.
+ 
+ option(VPP_BUFFER_FAULT_INJECTOR "Include the buffer fault injector" OFF)
++option(VPP_ENABLE_SYSTEMD_NOTIFY "Enable systemd notify support" OFF)
+ 
+ ##############################################################################
+ # Generate vlib/config.h
+@@ -22,6 +23,22 @@ else()
+   set(BUFFER_ALLOC_FAULT_INJECTOR 0 CACHE STRING "fault injector off")
+ endif()
+ 
++if(VPP_ENABLE_SYSTEMD_NOTIFY)
++  # Check for systemd library
++  vpp_find_path(SYSTEMD_INCLUDE_DIR systemd/sd-daemon.h)
++  vpp_find_library(SYSTEMD_LIB NAMES systemd)
++  
++  if(SYSTEMD_INCLUDE_DIR AND SYSTEMD_LIB)
++    message(STATUS "systemd found at ${SYSTEMD_LIB}")
++    set(SYSTEMD_NOTIFY_ENABLED 1 CACHE STRING "systemd notify enabled")
++  else()
++    message(WARNING "VPP_ENABLE_SYSTEMD_NOTIFY is ON but systemd library not found")
++    set(SYSTEMD_NOTIFY_ENABLED 0 CACHE STRING "systemd notify disabled")
++  endif()
++else()
++  set(SYSTEMD_NOTIFY_ENABLED 0 CACHE STRING "systemd notify disabled")
++endif()
++
+ if(VPP_PLATFORM_BUFFER_ALIGN)
+   set(VLIB_BUFFER_ALIGN ${VPP_PLATFORM_BUFFER_ALIGN})
+ else()
+@@ -73,6 +90,10 @@ endif()
+ 
+ set(VLIB_LIBS vppinfra svm ${CMAKE_DL_LIBS} ${EPOLL_LIB})
+ 
++if(SYSTEMD_NOTIFY_ENABLED)
++  list(APPEND VLIB_LIBS ${SYSTEMD_LIB})
++endif()
++
+ vpp_find_path(LIBIBERTY_INCLUDE_DIR libiberty/demangle.h)
+ vpp_find_library(LIBIBERTY_LIB NAMES iberty libiberty)
+ 
+diff --git a/src/vlib/config.h.in b/src/vlib/config.h.in
+index b233b327d..83c1e1335 100644
+--- a/src/vlib/config.h.in
++++ b/src/vlib/config.h.in
+@@ -20,5 +20,6 @@
+ #define VLIB_BUFFER_ALIGN @VLIB_BUFFER_ALIGN@
+ #define VLIB_BUFFER_ALLOC_FAULT_INJECTOR @BUFFER_ALLOC_FAULT_INJECTOR@
+ #define VLIB_PROCESS_LOG2_STACK_SIZE @VLIB_PROCESS_LOG2_STACK_SIZE@
++#define VLIB_SYSTEMD_NOTIFY_ENABLED @SYSTEMD_NOTIFY_ENABLED@
+ 
+ #endif
+diff --git a/src/vlib/unix/main.c b/src/vlib/unix/main.c
+index cd1f1e1c9..927bcdc0a 100644
+--- a/src/vlib/unix/main.c
++++ b/src/vlib/unix/main.c
+@@ -54,6 +54,10 @@
+ #include <sys/resource.h>
+ #include <unistd.h>
+ 
++#if VLIB_SYSTEMD_NOTIFY_ENABLED
++#include <systemd/sd-daemon.h>
++#endif
++
+ #ifdef HAVE_LIBIBERTY
+ #include <libiberty/demangle.h>
+ #endif
+@@ -79,6 +83,27 @@ unix_main_init (vlib_main_t * vm)
+ 
+ VLIB_INIT_FUNCTION (unix_main_init);
+ 
++#if VLIB_SYSTEMD_NOTIFY_ENABLED
++static void
++vlib_unix_systemd_notify_ready (void)
++{
++  unix_main_t *um = &unix_main;
++
++  /* Only notify if configured to do so */
++  if (um->flags & UNIX_FLAG_SYSTEMD_NOTIFY)
++    {
++      /* Notify systemd that we are ready */
++      int rc = sd_notify (0, "READY=1");
++      if (rc < 0)
++	{
++	  clib_warning ("systemd sd_notify failed: %s", strerror (-rc));
++	}
++      /* rc > 0 means successfully notified, rc == 0 means not running under
++       * systemd or notifications disabled - both are normal, no logging */
++    }
++}
++#endif /* VLIB_SYSTEMD_NOTIFY_ENABLED */
++
+ static int
+ unsetup_signal_handlers (int sig)
+ {
+@@ -358,6 +383,12 @@ startup_config_process (vlib_main_t * vm,
+ 
+   if (!um->startup_config_filename)
+     {
++#if VLIB_SYSTEMD_NOTIFY_ENABLED
++      /* Notify systemd that VPP is fully ready.
++       * This ensures dependent services only start after VPP is fully configured
++       * and ready to process packets. */
++      vlib_unix_systemd_notify_ready ();
++#endif
+       return 0;
+     }
+ 
+@@ -368,6 +399,13 @@ startup_config_process (vlib_main_t * vm,
+ 
+   unformat_free (&in);
+ 
++#if VLIB_SYSTEMD_NOTIFY_ENABLED
++  /* Notify systemd that VPP is fully ready after configuration is loaded.
++   * This ensures dependent services only start after VPP is fully configured
++   * and ready to process packets. */
++  vlib_unix_systemd_notify_ready ();
++#endif
++
+   return 0;
+ }
+ 
+@@ -405,6 +443,10 @@ unix_config (vlib_main_t * vm, unformat_input_t * input)
+ 	um->flags |= UNIX_FLAG_NOCOLOR;
+       else if (unformat (input, "nobanner"))
+ 	um->flags |= UNIX_FLAG_NOBANNER;
++#if VLIB_SYSTEMD_NOTIFY_ENABLED
++      else if (unformat (input, "systemd-notify"))
++	um->flags |= UNIX_FLAG_SYSTEMD_NOTIFY;
++#endif
+       else if (unformat (input, "cli-prompt %s", &cli_prompt))
+ 	vlib_unix_cli_set_prompt (cli_prompt);
+       else
+@@ -596,6 +638,13 @@ unix_config (vlib_main_t * vm, unformat_input_t * input)
+  * @cfgcmd{nobanner}
+  * Do not display startup banner.
+  *
++ * @cfgcmd{systemd-notify}
++ * Enable systemd notification when VPP is fully initialized and ready.
++ * Allows systemd to properly track VPP startup and manage service dependencies.
++ * This option is only available if VPP was built with systemd support
++ * (VPP_ENABLE_SYSTEMD_NOTIFY=ON). If not built with this support, the option
++ * will be ignored.
++ *
+  * @cfgcmd{exec, &lt;filename&gt;}
+  * @par <code>startup-config &lt;filename&gt;</code>
+  * Read startup operational configuration from @c filename.
+diff --git a/src/vlib/unix/unix.h b/src/vlib/unix/unix.h
+index d0b7a4c70..eb2dc4936 100644
+--- a/src/vlib/unix/unix.h
++++ b/src/vlib/unix/unix.h
+@@ -62,6 +62,7 @@ typedef struct
+ #define UNIX_FLAG_NOSYSLOG (1 << 2)
+ #define UNIX_FLAG_NOCOLOR (1 << 3)
+ #define UNIX_FLAG_NOBANNER (1 << 4)
++#define UNIX_FLAG_SYSTEMD_NOTIFY (1 << 5)
+ 
+ 
+   /* CLI listen socket. */
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Update patches, add optional systemd notify support for service readiness

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7970

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
