### PR TITLE
T8251: VPP sync IPsec SA counters to Linux XFRM via NEWAE

### DIFF
--- a/patches/vpp/0027-linux-cp-T8251-sync-VPP-IPsec-SA-counters-to-Linux-X.patch
+++ b/patches/vpp/0027-linux-cp-T8251-sync-VPP-IPsec-SA-counters-to-Linux-X.patch
@@ -1,0 +1,177 @@
+From d230a9463b518533151e5fb99e6b3457985e4c1a Mon Sep 17 00:00:00 2001
+From: Denys Haryachyy <garyachy@gmail.com>
+Date: Fri, 13 Feb 2026 15:09:08 +0200
+Subject: [PATCH] linux-cp: T8251: sync VPP IPsec SA counters to Linux XFRM via
+ NEWAE
+
+Push VPP's per-SA byte/packet counters into the corresponding Linux
+XFRM states via XFRM_MSG_NEWAE netlink messages every 2 seconds.
+
+lcp_xfrm_send_newae() builds a packed NEWAE netlink message
+(sa_newae_req_nl_t) with the SA identity and XFRMA_LTIME_VAL attribute,
+then sends it with NLM_F_REPLACE so the kernel overwrites existing
+counters.
+
+lcp_xfrm_sync_sa_counter() is called from check_for_expiry() for each
+SA, skipping unchanged counters and hard-expired SAs.
+
+Also fixes:
+  - Memory leak in send_nl_msg(): added missing nlmsg_free(nlmsg).
+---
+ src/plugins/linux-cp/lcp_ipsec.c   | 85 ++++++++++++++++++++++++++++++
+ src/plugins/linux-cp/lcp_xfrm_nl.c |  1 +
+ 2 files changed, 86 insertions(+)
+
+diff --git a/src/plugins/linux-cp/lcp_ipsec.c b/src/plugins/linux-cp/lcp_ipsec.c
+index 730dd648d..70ee7dad5 100644
+--- a/src/plugins/linux-cp/lcp_ipsec.c
++++ b/src/plugins/linux-cp/lcp_ipsec.c
+@@ -143,6 +143,13 @@ uword *lifetime_by_sa_id;
+ static int config_bypass = 0;
+ uword *tun_idx_by_sel_daddr;
+ 
++typedef struct sa_counter_sync
++{
++  u64 last_synced_bytes;
++  u64 last_synced_packets;
++  u8 expired;
++} sa_counter_sync_t;
++
+ typedef struct sa_life_limits
+ {
+   u64 soft_byte_limit;
+@@ -155,6 +162,8 @@ typedef struct sa_life_limits
+   /* Used in tunnel mode */
+   int tun_sw_if_idx;
+   u8 sa_in_tunnel;
++
++  sa_counter_sync_t sync; /* XFRM counter sync state */
+ } sa_life_limits_t;
+ 
+ typedef struct policy_db
+@@ -168,6 +177,13 @@ typedef struct sa_expire_req
+   struct xfrm_user_expire xfrm_expire;
+ } sa_expire_req_nl_t;
+ 
++typedef CLIB_PACKED (struct sa_newae_req {
++  struct nlmsghdr nlmsg_hdr;
++  struct xfrm_aevent_id ae_id;
++  struct nlattr nla;
++  struct xfrm_lifetime_cur ltime;
++}) sa_newae_req_nl_t;
++
+ static inline int
+ lcp_xfrm_is_ipsec_intf_exist (u8 *if_name, u32 *sw_if_index)
+ {
+@@ -1054,6 +1070,7 @@ nl_xfrm_sa_add (struct xfrmnl_sa *sa)
+   lifetime.reqid = xfrmnl_sa_get_reqid (sa);
+   lifetime.sa_in_tunnel = 0;
+   lifetime.tun_sw_if_idx = ~0;
++  clib_memset (&lifetime.sync, 0, sizeof (lifetime.sync));
+ 
+   proto =
+     (50 == xfrmnl_sa_get_proto (sa)) ? IPSEC_PROTOCOL_ESP : IPSEC_PROTOCOL_AH;
+@@ -1761,6 +1778,71 @@ build_nl_expire_msg (ipsec_sa_t *sa, u8 is_hard)
+   return send_nl_msg (&expire_req.nlmsg_hdr, XFRMGRP_EXPIRE, XFRM_MSG_EXPIRE);
+ }
+ 
++static u8
++lcp_xfrm_send_newae (ipsec_sa_t *sa, sa_life_limits_t *life, u64 total_bytes,
++		     u64 total_packets)
++{
++  sa_newae_req_nl_t newae_req;
++
++  memset (&newae_req, 0, sizeof (newae_req));
++
++  /* Fill up the nl header */
++  newae_req.nlmsg_hdr.nlmsg_len = sizeof (newae_req);
++  newae_req.nlmsg_hdr.nlmsg_type = XFRM_MSG_NEWAE;
++  newae_req.nlmsg_hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_REPLACE;
++  newae_req.nlmsg_hdr.nlmsg_seq = ++g_seq;
++  newae_req.nlmsg_hdr.nlmsg_pid = nl_socket_get_local_port (nm->sk_xfrm);
++
++  /* Fill up the xfrm_aevent_id with SA info */
++  newae_req.ae_id.sa_id.spi = clib_host_to_net_u32 (sa->spi);
++  newae_req.ae_id.sa_id.proto =
++    (sa->protocol == IPSEC_PROTOCOL_ESP) ? IPPROTO_ESP : IPPROTO_AH;
++  newae_req.ae_id.sa_id.family =
++    (sa->tunnel.t_dst.version == AF_IP4) ? AF_INET : AF_INET6;
++
++  if (sa->tunnel.t_dst.version == AF_IP4)
++    newae_req.ae_id.sa_id.daddr.a4 = sa->tunnel.t_dst.ip.ip4.as_u32;
++  else
++    clib_memcpy_fast (&newae_req.ae_id.sa_id.daddr.a6,
++		      &sa->tunnel.t_dst.ip.ip6.as_u32, sizeof (ip6_address_t));
++
++  if (sa->tunnel.t_src.version == AF_IP4)
++    newae_req.ae_id.saddr.a4 = sa->tunnel.t_src.ip.ip4.as_u32;
++  else
++    clib_memcpy_fast (&newae_req.ae_id.saddr.a6,
++		      &sa->tunnel.t_src.ip.ip6.as_u32, sizeof (ip6_address_t));
++
++  newae_req.ae_id.flags = XFRM_AE_LVAL;
++  newae_req.ae_id.reqid = life->reqid;
++
++  /* NLA: XFRMA_LTIME_VAL */
++  newae_req.nla.nla_len = NLA_HDRLEN + sizeof (struct xfrm_lifetime_cur);
++  newae_req.nla.nla_type = XFRMA_LTIME_VAL;
++
++  newae_req.ltime.bytes = total_bytes;
++  newae_req.ltime.packets = total_packets;
++
++  return send_nl_msg (&newae_req.nlmsg_hdr, 0, XFRM_MSG_NEWAE);
++}
++
++static inline void
++lcp_xfrm_sync_sa_counter (ipsec_sa_t *sa, sa_life_limits_t *life,
++			  vlib_counter_t *count)
++{
++  if (life->sync.expired)
++    return;
++
++  if (count->bytes == life->sync.last_synced_bytes &&
++      count->packets == life->sync.last_synced_packets)
++    return;
++
++  if (lcp_xfrm_send_newae (sa, life, count->bytes, count->packets))
++    {
++      life->sync.last_synced_bytes = count->bytes;
++      life->sync.last_synced_packets = count->packets;
++    }
++}
++
+ u8
+ check_for_expiry ()
+ {
+@@ -1779,6 +1861,8 @@ check_for_expiry ()
+       life = (sa_life_limits_t *) p[0];
+       vlib_get_combined_counter (&ipsec_sa_counters, sa->stat_index, &count);
+ 
++      lcp_xfrm_sync_sa_counter (sa, life, &count);
++
+       if ((count.packets >= life->hard_packet_limit) ||
+ 	  (count.bytes >= life->hard_byte_limit))
+ 	{
+@@ -1786,6 +1870,7 @@ check_for_expiry ()
+ 	    "HARD EXPIRY said : %x CntPkt: %u SoftPkt: %u HardPkt: %u", sa->id,
+ 	    count.packets, life->soft_packet_limit, life->hard_packet_limit);
+ 	  rv = build_nl_expire_msg (sa, 1);
++	  life->sync.expired = 1;
+ 	}
+       else if ((count.packets >= life->soft_packet_limit) ||
+ 	       (count.bytes >= life->soft_byte_limit))
+diff --git a/src/plugins/linux-cp/lcp_xfrm_nl.c b/src/plugins/linux-cp/lcp_xfrm_nl.c
+index 9c5bb88c6..e7148584a 100644
+--- a/src/plugins/linux-cp/lcp_xfrm_nl.c
++++ b/src/plugins/linux-cp/lcp_xfrm_nl.c
+@@ -117,6 +117,7 @@ send_nl_msg (struct nlmsghdr *nl_hdr, unsigned int groups, u8 msg_type)
+   nl_addr.nl_pid = 0;
+ 
+   status = nl_sendmsg (sk_xfrm, nlmsg, &msg);
++  nlmsg_free (nlmsg);
+   if (status < 0)
+     {
+       NL_ERROR ("Expiry send failed");
+-- 
+2.39.5
+


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Push VPP's per-SA byte/packet counters into the corresponding Linux XFRM states via XFRM_MSG_NEWAE netlink messages every 2 seconds.

lcp_xfrm_send_newae() builds a packed NEWAE netlink message (sa_newae_req_nl_t) with the SA identity and XFRMA_LTIME_VAL attribute, then sends it with NLM_F_REPLACE so the kernel overwrites existing counters.

lcp_xfrm_sync_sa_counter() is called from check_for_expiry() for each SA, skipping unchanged counters and hard-expired SAs.

Also fixes:
  - Memory leak in send_nl_msg(): added missing nlmsg_free(nlmsg).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8251

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
