### PR TITLE
T7513: Add VPP tests corresponding to det44 identity mappings

### DIFF
--- a/patches/vpp/0031-PPPoE-Added-cp_binding_dump-API-call-49.patch
+++ b/patches/vpp/0031-PPPoE-Added-cp_binding_dump-API-call-49.patch
@@ -1,0 +1,181 @@
+From b0254311c5329864f96a7adef69a72be88bff89f Mon Sep 17 00:00:00 2001
+From: Fullroot <51375681+AndriiFullroot@users.noreply.github.com>
+Date: Thu, 9 Apr 2026 14:40:51 +0200
+Subject: [PATCH] PPPoE: Added cp_binding_dump API call (#49)
+
+Added dump API call that returns PPPoE's cp/dp interfaces.
+By default, it returns ALL bindings.
+The argument sw_if_index to request may be added.
+That would specify to "dump" only the binding where
+dataplane or control plane is equal to the argument.
+
+Change-Id: I6091d350a2cb98c34aecb883effb36af61e0c1ca
+
+Signed-off-by: Andrii Melnychenko <a.melnychenko@vyos.io>
+---
+ src/plugins/pppoe/pppoe.api    | 28 +++++++++++++++
+ src/plugins/pppoe/pppoe_api.c  | 63 ++++++++++++++++++++++++++++++++++
+ src/plugins/pppoe/pppoe_test.c | 36 +++++++++++++++++++
+ 3 files changed, 127 insertions(+)
+
+diff --git a/src/plugins/pppoe/pppoe.api b/src/plugins/pppoe/pppoe.api
+index d8f6c93db..ff339d248 100644
+--- a/src/plugins/pppoe/pppoe.api
++++ b/src/plugins/pppoe/pppoe.api
+@@ -113,6 +113,34 @@ define pppoe_add_del_cp_reply
+   i32 retval;
+ };
+ 
++/** \brief dump details of control-to-data plane PPPoE bindings
++    @param context - sender context, to match reply w/ request
++    @param retval - possible error code, 0 - is success
++    @param dp_sw_if_index - dataplane software index of the interface
++    @param cp_sw_if_index - control plane software index of the interface
++*/
++define pppoe_cp_binding_details
++{
++  u32 context;
++  i32 retval;
++  vl_api_interface_index_t dp_sw_if_index;
++  vl_api_interface_index_t cp_sw_if_index;
++};
++
++/** \brief dump control-to-data plane PPPoE bindings
++    @param client_index - opaque cookie to identify the sender
++    @param context - sender context, to match reply w/ request
++    @param sw_if_index - control or data plane software index of the interface
++*/
++define pppoe_cp_binding_dump
++{
++  u32 client_index;
++  u32 context;
++  vl_api_interface_index_t sw_if_index [default=0xFFFFFFFF];
++  option vat_help = "[sw_if_index <nn>]";
++};
++
++
+ /*
+  * Local Variables:
+  * eval: (c-set-style "gnu")
+diff --git a/src/plugins/pppoe/pppoe_api.c b/src/plugins/pppoe/pppoe_api.c
+index 2e663c690..ef47a7053 100644
+--- a/src/plugins/pppoe/pppoe_api.c
++++ b/src/plugins/pppoe/pppoe_api.c
+@@ -149,6 +149,69 @@ vl_api_pppoe_add_del_cp_t_handler (vl_api_pppoe_add_del_cp_t * mp)
+   REPLY_MACRO(VL_API_PPPOE_ADD_DEL_CP_REPLY);
+ }
+ 
++static void send_pppoe_cp_binding_details
++  (vl_api_registration_t * reg, u32 context, vl_api_interface_index_t cp_sw_if_index, vl_api_interface_index_t dp_sw_if_index, i32 rv)
++{
++  vl_api_pppoe_cp_binding_details_t *rmp;
++  pppoe_main_t *pem = &pppoe_main;
++
++  rmp = vl_msg_api_alloc (sizeof (*rmp));
++  clib_memset (rmp, 0, sizeof (*rmp));
++  rmp->_vl_msg_id = ntohs (pem->msg_id_base + VL_API_PPPOE_CP_BINDING_DETAILS);
++  rmp->context = context;
++
++  rmp->cp_sw_if_index = htonl(cp_sw_if_index);
++  rmp->dp_sw_if_index = htonl(dp_sw_if_index);
++  rmp->retval = htonl(rv);
++
++  vl_api_send_msg (reg, (u8 *) rmp);
++}
++
++static void
++vl_api_pppoe_cp_binding_dump_t_handler (vl_api_pppoe_cp_binding_dump_t * mp)
++{
++  pppoe_main_t *pem = &pppoe_main;
++  i32 rv = 0;
++  vl_api_interface_index_t sw_if_index = ntohl(mp->sw_if_index);
++  vl_api_registration_t *reg;
++
++  reg = vl_api_client_index_to_registration (mp->client_index);
++
++  if (~0 == mp->sw_if_index)
++    {
++      for (int i = 0; i < vec_len(pem->cp_if_index_by_sw_if_index); i++)
++	{
++	  if (pem->cp_if_index_by_sw_if_index[i] != ~0)
++	    send_pppoe_cp_binding_details(reg, mp->context, pem->cp_if_index_by_sw_if_index[i], i, rv);
++	}
++    }
++  else
++    {
++      vl_api_interface_index_t cp_if;
++      vl_api_interface_index_t dp_if;
++
++      cp_if = sw_if_index < vec_len(pem->cp_if_index_by_sw_if_index) ?
++	    pem->cp_if_index_by_sw_if_index[sw_if_index] : ~0;
++      dp_if = sw_if_index;
++
++      if (cp_if == ~0)
++	{
++	  cp_if = sw_if_index;
++	  dp_if = sw_if_index < vec_len(pem->dp_if_index_by_sw_if_index) ?
++	    pem->dp_if_index_by_sw_if_index[sw_if_index] : ~0;
++	}
++
++      if (dp_if == ~0)
++	{
++	  cp_if = ~0;
++	  dp_if = ~0;
++	  rv = VNET_API_ERROR_INVALID_INTERFACE;
++	}
++
++      send_pppoe_cp_binding_details(reg, mp->context, cp_if, dp_if, rv);
++    }
++}
++
+ #include <pppoe/pppoe.api.c>
+ static clib_error_t *
+ pppoe_api_hookup (vlib_main_t * vm)
+diff --git a/src/plugins/pppoe/pppoe_test.c b/src/plugins/pppoe/pppoe_test.c
+index ecb8d7f4c..c895aba3c 100644
+--- a/src/plugins/pppoe/pppoe_test.c
++++ b/src/plugins/pppoe/pppoe_test.c
+@@ -286,4 +286,40 @@ api_pppoe_add_del_cp (vat_main_t * vam)
+   return ret;
+ }
+ 
++static void
++vl_api_pppoe_cp_binding_details_t_handler (vl_api_pppoe_cp_binding_details_t * mp)
++{
++  vat_main_t *vam = &vat_main;
++  i32 rv = ntohl (mp->retval);
++  if (rv)
++    {
++      print (vam->ofp, "error: %d", rv);
++      return;
++    }
++  print (vam->ofp, "dp_sw_if_index: %d  cp_sw_if_index: %d",
++	ntohl (mp->dp_sw_if_index), ntohl (mp->cp_sw_if_index));
++}
++
++static int
++api_pppoe_cp_binding_dump (vat_main_t * vam)
++{
++  vl_api_pppoe_cp_binding_dump_t *mp;
++  unformat_input_t *i = vam->input;
++  int ret;
++  u32 sw_if_index = ~0;
++
++  /* Parse args required to build the message */
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++      if (!unformat (i, "sw_if_index %d", &sw_if_index))
++	break;
++    }
++
++  M (PPPOE_CP_BINDING_DUMP, mp);
++  mp->sw_if_index = htonl(sw_if_index);
++  S (mp);
++  W (ret);
++  return ret;
++}
++
+ #include <pppoe/pppoe.api_test.c>
+-- 
+2.39.5
+

--- a/patches/vpp/0032-T7513-VPP-tests-det44-identity-mappings-50.patch
+++ b/patches/vpp/0032-T7513-VPP-tests-det44-identity-mappings-50.patch
@@ -1,0 +1,330 @@
+From aec34afc0d96cfb1efc9ccceccf67333e5ccb048 Mon Sep 17 00:00:00 2001
+From: RC <ritika0313@gmail.com>
+Date: Thu, 9 Apr 2026 07:34:41 -0700
+Subject: [PATCH] T7513: VPP tests - det44 identity mappings (#50)
+
+Added vpp tests corresponding to det44 identity mappings implementation
+---
+ test/test_det44.py | 274 ++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 273 insertions(+), 1 deletion(-)
+
+diff --git a/test/test_det44.py b/test/test_det44.py
+index 11d33ef0a..2cb80b76d 100644
+--- a/test/test_det44.py
++++ b/test/test_det44.py
+@@ -7,18 +7,20 @@ import scapy.compat
+ from time import sleep
+ from config import config
+ from framework import VppTestCase
++from vpp_papi import VppEnum
+ from ipfix import IPFIX, Set, Template, Data, IPFIXDecoder
+ from scapy.layers.inet import IP, TCP, UDP, ICMP
+ from scapy.layers.inet import IPerror, UDPerror
+ from scapy.layers.l2 import Ether
+ from util import ppp
+-from config import config
+ 
+ 
+ @unittest.skipIf("nat" in config.excluded_plugins, "Exclude NAT plugin tests")
+ class TestDET44(VppTestCase):
+     """Deterministic NAT Test Cases"""
+ 
++    NAT_IS_ADDR_ONLY = VppEnum.vl_api_nat_config_flags_t.NAT_IS_ADDR_ONLY
++
+     @classmethod
+     def setUpClass(cls):
+         super(TestDET44, cls).setUpClass()
+@@ -59,6 +61,7 @@ class TestDET44(VppTestCase):
+         self.logger.info(self.vapi.cli("show det44 interfaces"))
+         self.logger.info(self.vapi.cli("show det44 timeouts"))
+         self.logger.info(self.vapi.cli("show det44 mappings"))
++        self.logger.info(self.vapi.cli("show det44 identity mappings"))
+         self.logger.info(self.vapi.cli("show det44 sessions"))
+ 
+     def verify_capture_in(self, capture, in_if):
+@@ -246,6 +249,28 @@ class TestDET44(VppTestCase):
+                 )
+                 raise
+ 
++    def find_identity_mapping(self, addr, protocol=None, port=None, addr_only=None):
++        mappings = self.vapi.det44_identity_mapping_dump()
++        for mapping in mappings:
++            if str(mapping.addr) != addr:
++                continue
++            if protocol is not None and mapping.protocol != protocol:
++                continue
++            if port is not None and mapping.port != port:
++                continue
++            if addr_only is not None:
++                mapping_is_addr_only = bool(mapping.flags & self.NAT_IS_ADDR_ONLY)
++                if mapping_is_addr_only != addr_only:
++                    continue
++            return mapping
++        return None
++
++    def get_identity_mappings_cli(self, log_output=True):
++        output = self.vapi.cli("show det44 identity mappings")
++        if log_output:
++            self.logger.info(output)
++        return output
++
+     def test_deterministic_mode(self):
+         """NAT plugin run deterministic mode"""
+         in_addr = "172.16.255.0"
+@@ -659,6 +684,253 @@ class TestDET44(VppTestCase):
+         dms = self.vapi.det44_map_dump()
+         self.assertEqual(0, dms[0].ses_num)
+ 
++    def test_identity_mapping_address_only(self):
++        """DET44 identity mapping add/dump/delete (address only)"""
++
++        addr = self.pg0.remote_ip4
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=1,
++            addr=addr,
++            protocol=0,
++            port=0,
++            flags=self.NAT_IS_ADDR_ONLY,
++            tag="addr-only",
++        )
++
++        mapping = self.find_identity_mapping(addr, addr_only=True)
++        self.assertIsNotNone(mapping)
++        self.assertEqual(str(mapping.addr), addr)
++        self.assertEqual(mapping.port, 0)
++        self.assertTrue(mapping.flags & self.NAT_IS_ADDR_ONLY)
++
++        cli_out = self.get_identity_mappings_cli()
++        self.assertIn("DET44 identity mappings", cli_out)
++        self.assertIn(addr, cli_out)
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=0,
++            addr=addr,
++            protocol=0,
++            port=0,
++            flags=self.NAT_IS_ADDR_ONLY,
++            tag="",
++        )
++
++        self.assertIsNone(self.find_identity_mapping(addr, addr_only=True))
++        self.assertIn(
++            "DET44 identity mappings: none",
++            self.get_identity_mappings_cli(log_output=False),
++        )
++
++    def test_identity_mapping_with_proto_port(self):
++        """DET44 identity mapping add/dump/delete (TCP + port)"""
++
++        addr = self.pg0.remote_ip4
++        proto_tcp = 6
++        port = 443
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=1,
++            addr=addr,
++            protocol=proto_tcp,
++            port=port,
++            flags=0,
++            tag="tcp-443",
++        )
++
++        mapping = self.find_identity_mapping(
++            addr, protocol=proto_tcp, port=port, addr_only=False
++        )
++        self.assertIsNotNone(mapping)
++        self.assertEqual(str(mapping.addr), addr)
++        self.assertEqual(mapping.protocol, proto_tcp)
++        self.assertEqual(mapping.port, port)
++        self.assertFalse(mapping.flags & self.NAT_IS_ADDR_ONLY)
++
++        cli_out = self.get_identity_mappings_cli()
++        self.assertIn("DET44 identity mappings", cli_out)
++        self.assertIn(addr, cli_out)
++        self.assertIn("tcp", cli_out.lower())
++        self.assertIn(str(port), cli_out)
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=0,
++            addr=addr,
++            protocol=proto_tcp,
++            port=port,
++            flags=0,
++            tag="",
++        )
++
++        self.assertIsNone(
++            self.find_identity_mapping(
++                addr, protocol=proto_tcp, port=port, addr_only=False
++            )
++        )
++        self.assertIn(
++            "DET44 identity mappings: none",
++            self.get_identity_mappings_cli(log_output=False),
++        )
++
++    def test_identity_mapping_bypass_translation_addr_only(self):
++        """DET44 identity mapping bypasses translation for matching flow"""
++
++        nat_ip = "10.0.0.10"
++        src_ip = self.pg0.remote_ip4
++        dst_ip = self.pg1.remote_ip4
++
++        self.vapi.det44_add_del_map(
++            is_add=1,
++            in_addr=src_ip,
++            in_plen=32,
++            out_addr=socket.inet_aton(nat_ip),
++            out_plen=32,
++        )
++        self.vapi.det44_interface_add_del_feature(
++            sw_if_index=self.pg0.sw_if_index, is_add=1, is_inside=1
++        )
++        self.vapi.det44_interface_add_del_feature(
++            sw_if_index=self.pg1.sw_if_index, is_add=1, is_inside=0
++        )
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=1,
++            addr=src_ip,
++            protocol=0,
++            port=0,
++            flags=self.NAT_IS_ADDR_ONLY,
++            tag="bypass",
++        )
++
++        cli_out = self.get_identity_mappings_cli()
++        self.assertIn("DET44 identity mappings", cli_out)
++        self.assertIn(src_ip, cli_out)
++
++        p = (
++            Ether(src=self.pg0.remote_mac, dst=self.pg0.local_mac)
++            / IP(src=src_ip, dst=dst_ip)
++            / TCP(sport=1111, dport=self.tcp_external_port)
++        )
++        self.pg0.add_stream(p)
++        self.pg_enable_capture(self.pg_interfaces)
++        self.pg_start()
++        capture = self.pg1.get_capture(1)
++        self.assertEqual(capture[0][IP].src, src_ip)
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=0,
++            addr=src_ip,
++            protocol=0,
++            port=0,
++            flags=self.NAT_IS_ADDR_ONLY,
++            tag="",
++        )
++
++        self.assertIn(
++            "DET44 identity mappings: none",
++            self.get_identity_mappings_cli(log_output=False),
++        )
++
++        p = (
++            Ether(src=self.pg0.remote_mac, dst=self.pg0.local_mac)
++            / IP(src=src_ip, dst=dst_ip)
++            / TCP(sport=2222, dport=self.tcp_external_port)
++        )
++        self.pg0.add_stream(p)
++        self.pg_enable_capture(self.pg_interfaces)
++        self.pg_start()
++        capture = self.pg1.get_capture(1)
++        self.assertEqual(capture[0][IP].src, nat_ip)
++
++    def test_identity_mapping_bypass_translation_with_proto_port(self):
++        """DET44 identity mapping bypasses only matching protocol+source port"""
++
++        nat_ip = "10.0.0.10"
++        src_ip = self.pg0.remote_ip4
++        dst_ip = self.pg1.remote_ip4
++        proto_tcp = 6
++        mapped_port = 443
++
++        self.vapi.det44_add_del_map(
++            is_add=1,
++            in_addr=src_ip,
++            in_plen=32,
++            out_addr=socket.inet_aton(nat_ip),
++            out_plen=32,
++        )
++        self.vapi.det44_interface_add_del_feature(
++            sw_if_index=self.pg0.sw_if_index, is_add=1, is_inside=1
++        )
++        self.vapi.det44_interface_add_del_feature(
++            sw_if_index=self.pg1.sw_if_index, is_add=1, is_inside=0
++        )
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=1,
++            addr=src_ip,
++            protocol=proto_tcp,
++            port=mapped_port,
++            flags=0,
++            tag="proto-port-bypass",
++        )
++
++        cli_out = self.get_identity_mappings_cli()
++        self.assertIn("DET44 identity mappings", cli_out)
++        self.assertIn(src_ip, cli_out)
++        self.assertIn("tcp", cli_out.lower())
++        self.assertIn(str(mapped_port), cli_out)
++
++        def send_and_verify(pkt, expected_src, remark):
++            self.vapi.cli("clear trace")
++            self.pg0.add_stream(pkt)
++            self.pg_enable_capture(self.pg_interfaces)
++            self.pg_start()
++            capture = self.pg1.get_capture(1, remark=remark)
++            actual_src = capture[0][IP].src
++            if actual_src != expected_src:
++                self.logger.error("Unexpected translated source in sub-case '%s'", remark)
++                self.logger.error(self.vapi.cli("show trace max 1000"))
++            self.assertEqual(actual_src, expected_src)
++
++        # Matching TCP source port should bypass translation
++        p = (
++            Ether(src=self.pg0.remote_mac, dst=self.pg0.local_mac)
++            / IP(src=src_ip, dst=dst_ip)
++            / TCP(sport=mapped_port, dport=self.tcp_external_port)
++        )
++        send_and_verify(p, src_ip, "tcp-match-bypass")
++
++        # Non-matching source port should still be translated
++        p = (
++            Ether(src=self.pg0.remote_mac, dst=self.pg0.local_mac)
++            / IP(src=src_ip, dst=dst_ip)
++            / TCP(sport=444, dport=self.tcp_external_port + 1)
++        )
++        send_and_verify(p, nat_ip, "tcp-port-mismatch-translate")
++
++        # Protocol mismatch (UDP same source port) should still be translated
++        p = (
++            Ether(src=self.pg0.remote_mac, dst=self.pg0.local_mac)
++            / IP(src=src_ip, dst=dst_ip)
++            / UDP(sport=mapped_port, dport=self.udp_external_port)
++        )
++        send_and_verify(p, nat_ip, "udp-proto-mismatch-translate")
++
++        self.vapi.det44_add_del_identity_mapping(
++            is_add=0,
++            addr=src_ip,
++            protocol=proto_tcp,
++            port=mapped_port,
++            flags=0,
++            tag="",
++        )
++
++        self.assertIn(
++            "DET44 identity mappings: none",
++            self.get_identity_mappings_cli(log_output=False),
++        )
++
+     # TODO: ipfix needs to be separated from NAT base plugin
+     @unittest.skipUnless(config.extended, "part of extended tests")
+     def test_session_limit_per_user(self):
+-- 
+2.39.5
+


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
 - T7513: Added vpp tests corresponding to det44 identity mappings implementation
 - PPPoE: Added cp_binding_dump API call

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7513

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
