### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,3 @@ Twin at `VyOS-Networks/vyos-vpp-patches`. Canonical side here.
 - Patch order matters — renumber carefully on rebase.
 - Patches encode VyOS task IDs (T7770, T7775, T8551, …) in subjects; preserve the `linux-cp-T8XXX-…` style.
 - Verify each patch still applies cleanly to the upstream VPP version pinned by the consumer build.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-vpp-patches`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282980). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+## Project purpose
+A series of `.patch` files applied to upstream VPP (Vector Packet Processing) during the VyOS VPP build, to add VyOS-specific features and fixes.
+
+## Tech stack
+- Plain text quilt-style patches (numbered `0001-…`, `0002-…`, …) in `patches/vpp/`.
+- No build system in tree; patches are consumed by `vyos/vpp` and/or `VyOS-Networks/vyos-vpp` build pipelines.
+
+## Build / test / run
+- Apply with `quilt push -a` (or `git am`) inside the upstream VPP source tree.
+- No tests in this repo; verification happens in the VPP package build and image-level smoketests run by `vyos-build`.
+
+## Repository layout
+- `patches/vpp/` — numbered patch series, e.g. `0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch`, `0013-pppoe.-Automated-session-management.patch`, `0020-version-Implement-VyOS-specific-versioning-format.patch`.
+- `LICENSE` — GPL-3.0.
+- `README.md` — one-line pitch.
+- `.github/` — minimal reusable-workflow wiring.
+
+## Cross-repo context
+- Consumed by `vyos/vpp` (the VyOS-flavored VPP fork — C) and `VyOS-Networks/vyos-vpp` (the integration package). Together with `VyOS-Networks/vyos-stream-builds`'s `vyos-reusable-vpp-build.yml`, this provides VPP fast-path support for VyOS images.
+- Patches touch areas like Linux-CP (`linux-cp-…`), IPsec/XFRM, PPPoE session mgmt, AEAD/AES-GCM crypto.
+
+## Conventions
+- One feature/fix per numbered patch; keep them rebased against the upstream VPP tag the build targets.
+- Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
+- Default branch `current`.
+
+## Mirror relationship
+Twin at `VyOS-Networks/vyos-vpp-patches`. Canonical side here.
+
+## Notes for future contributors
+- Patch order matters — renumber carefully on rebase.
+- Patches encode VyOS task IDs (T7770, T7775, T8551, …) in subjects; preserve the `linux-cp-T8XXX-…` style.
+- Verify each patch still applies cleanly to the upstream VPP version pinned by the consumer build.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-vpp-patches`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282980). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
