### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../CLAUDE.md
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,35 @@
-CLAUDE.md
+# AGENTS.md
+
+## Project purpose
+A series of `.patch` files applied to upstream VPP (Vector Packet Processing) during the VyOS VPP build, to add VyOS-specific features and fixes.
+
+## Tech stack
+- Plain text quilt-style patches (numbered `0001-…`, `0002-…`, …) in `patches/vpp/`.
+- No build system in tree; patches are consumed by `vyos/vpp` and/or `VyOS-Networks/vyos-vpp` build pipelines.
+
+## Build / test / run
+- Apply with `quilt push -a` (or `git am`) inside the upstream VPP source tree.
+- No tests in this repo; verification happens in the VPP package build and image-level smoketests run by `vyos-build`.
+
+## Repository layout
+- `patches/vpp/` — numbered patch series, e.g. `0001-linux-cp-add-support-for-xfrm-netlink-notifcation.patch`, `0013-pppoe.-Automated-session-management.patch`, `0020-version-Implement-VyOS-specific-versioning-format.patch`.
+- `LICENSE` — GPL-3.0.
+- `README.md` — one-line pitch.
+- `.github/` — minimal reusable-workflow wiring.
+
+## Cross-repo context
+- Consumed by `vyos/vpp` (the VyOS-flavored VPP fork — C) and `VyOS-Networks/vyos-vpp` (the integration package). Together with `VyOS-Networks/vyos-stream-builds`'s `vyos-reusable-vpp-build.yml`, this provides VPP fast-path support for VyOS images.
+- Patches touch areas like Linux-CP (`linux-cp-…`), IPsec/XFRM, PPPoE session mgmt, AEAD/AES-GCM crypto.
+
+## Conventions
+- One feature/fix per numbered patch; keep them rebased against the upstream VPP tag the build targets.
+- Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
+- Default branch `current`.
+
+## Mirror relationship
+Twin at `VyOS-Networks/vyos-vpp-patches`. Canonical side here.
+
+## Notes for future contributors
+- Patch order matters — renumber carefully on rebase.
+- Patches encode VyOS task IDs (T7770, T7775, T8551, …) in subjects; preserve the `linux-cp-T8XXX-…` style.
+- Verify each patch still applies cleanly to the upstream VPP version pinned by the consumer build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ A series of `.patch` files applied to upstream VPP (Vector Packet Processing) du
 
 ## Tech stack
 - Plain text quilt-style patches (numbered `0001-…`, `0002-…`, …) in `patches/vpp/`.
-- No build system in tree; patches are consumed by `vyos/vpp` and/or `VyOS-Networks/vyos-vpp` build pipelines.
+- No build system in tree; patches are consumed by `vyos/vpp` and/or an internal repository build pipelines.
 
 ## Build / test / run
 - Apply with `quilt push -a` (or `git am`) inside the upstream VPP source tree.
@@ -18,16 +18,13 @@ A series of `.patch` files applied to upstream VPP (Vector Packet Processing) du
 - `.github/` — minimal reusable-workflow wiring.
 
 ## Cross-repo context
-- Consumed by `vyos/vpp` (the VyOS-flavored VPP fork — C) and `VyOS-Networks/vyos-vpp` (the integration package). Together with `VyOS-Networks/vyos-stream-builds`'s `vyos-reusable-vpp-build.yml`, this provides VPP fast-path support for VyOS images.
+- Consumed by `vyos/vpp` (the VyOS-flavored VPP fork — C) and an internal repository (the integration package). Together with an internal repository's `vyos-reusable-vpp-build.yml`, this provides VPP fast-path support for VyOS images.
 - Patches touch areas like Linux-CP (`linux-cp-…`), IPsec/XFRM, PPPoE session mgmt, AEAD/AES-GCM crypto.
 
 ## Conventions
 - One feature/fix per numbered patch; keep them rebased against the upstream VPP tag the build targets.
 - Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
 - Default branch `current`.
-
-## Mirror relationship
-Twin at `VyOS-Networks/vyos-vpp-patches`. Canonical side here.
 
 ## Notes for future contributors
 - Patch order matters — renumber carefully on rebase.


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
