### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ A series of `.patch` files applied to upstream VPP (Vector Packet Processing) du
 ## Conventions
 - One feature/fix per numbered patch; keep them rebased against the upstream VPP tag the build targets.
 - Commit / PR title: `component: T12345: description` (Phorge ID mandatory).
-- Default branch `current`.
+- Default branch `rolling`.
 
 ## Notes for future contributors
 - Patch order matters — renumber carefully on rebase.


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)