### PR TITLE
ci: T9047: grant pull-requests: read for paths-filter in rebuild trigger

### DIFF
--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -8,6 +8,10 @@ on:
       - rolling
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   get_repo_name:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an explicit `permissions:` block to `.github/workflows/trigger-rebuild-repo-package.yml`, granting `contents: read` + `pull-requests: read`. No other change.

## Why

The `get_repo_name` job's `dorny/paths-filter@v3` step ("Check if vpp patches changed") calls the PR-files API (`listFiles(pull_number, ...)`) using `secrets.GITHUB_TOKEN`. This workflow file had no `permissions:` block, so the job runs under whatever default token scope the org applies.

On the mirror twin (`VyOS-Networks/vyos-vpp-patches`), that default is restricted — verified against the latest run (`27107266214`), where the step fails with:

```
##[error]Resource not accessible by integration
```

logged immediately after `Invoking listFiles(pull_number: 69, per_page: 100)`. Confirmed across the job's step list: `get_repo_name` is the only failed job/step, `trigger-build-vpp` and `trigger-build-linux-kernel` are skipped as a result. An explicit `permissions:` block fixes this regardless of the org default, on both `vyos` and `VyOS-Networks`.

Note on the source-side (`vyos/vyos-vpp-patches`) intermittent failures: checked the last 20 runs of this workflow there — 4 failures, all at a *different* step (`trigger-build-vpp / "Trigger rebuild for vpp and wait for workflow to finish"`, in the downstream reusable workflow), with `get_repo_name`/paths-filter succeeding every time. That downstream job authenticates entirely via `secrets.PAT` (not `GITHUB_TOKEN`), so this permissions fix does not touch it and is not expected to affect those failures — flagging so it isn't mistaken for a fix to that separate issue.

Advances: IS-574

🤖 Generated by [robots](https://vyos.io)
