### PR TITLE
dpdk: T9161: Expose NIC max MTU and frame overhead in show hardware-interfaces

### DIFF
--- a/patches/vpp/0033-dpdk-T9161-expose-nic-mtu-limits-in-show-hardware-in.patch
+++ b/patches/vpp/0033-dpdk-T9161-expose-nic-mtu-limits-in-show-hardware-in.patch
@@ -1,0 +1,43 @@
+From 59a86088dcd9c6b19ca8e8ea1ffcc3f11abc5b1d Mon Sep 17 00:00:00 2001
+From: Nataliia Solomko <natalirs1985@gmail.com>
+Date: Mon, 31 Aug 2026 16:38:06 +0300
+Subject: [PATCH] dpdk: T9161: expose NIC max mtu and frame overhead in show
+ hardware-interfaces
+
+'show hardware-interfaces' prints only 'max rx packet len'
+(rte_eth_dev_info.max_rx_pktlen, the maximum RX packet length), which is not
+the maximum settable MTU - the two differ on some drivers (e.g. VMware
+VMXNET3: max_mtu 9000 vs a max rx packet len of 16384). Print
+rte_eth_dev_info.max_mtu ('max mtu') and xd->driver_frame_overhead so the
+true per-NIC MTU limit is queryable (VyOS uses it to reject an MTU the
+dataplane cannot honor, which would otherwise be silently capped while the
+kernel keeps the larger value).
+
+A max_mtu of UINT16_MAX is the PMD's "unknown/no limit" sentinel, which VPP
+itself distrusts (dpdk_set_max_frame_size guards on it), so render it as
+'unknown' rather than 65535 to avoid a consumer treating it as a real limit.
+---
+ src/plugins/dpdk/device/format.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/plugins/dpdk/device/format.c b/src/plugins/dpdk/device/format.c
+index f0199c9..0405a82 100644
+--- a/src/plugins/dpdk/device/format.c
++++ b/src/plugins/dpdk/device/format.c
+@@ -496,6 +496,13 @@ format_dpdk_device (u8 * s, va_list * args)
+ 
+   s = format (s, "%Umax rx packet len: %d\n", format_white_space, indent + 2,
+ 	      di.max_rx_pktlen);
++  if (di.max_mtu == UINT16_MAX)
++    s = format (s, "%Umax mtu: unknown\n", format_white_space, indent + 2);
++  else
++    s = format (s, "%Umax mtu: %d\n", format_white_space, indent + 2,
++	      di.max_mtu);
++  s = format (s, "%Udriver frame overhead: %d\n", format_white_space, indent + 2,
++	      xd->driver_frame_overhead);
+   s = format (s, "%Upromiscuous: unicast %s all-multicast %s\n",
+ 	      format_white_space, indent + 2,
+ 	      rte_eth_promiscuous_get (xd->port_id) ? "on" : "off",
+-- 
+2.51.0
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9161
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```
-->
```
vyos@vyos# set vpp settings interface eth1
[edit]
vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/

[edit]
vyos@vyos# sudo vppctl show hardware-interfaces eth1 | grep -iE 'max mtu|frame overhead'
    max mtu: 9698
    driver frame overhead: 30
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
